### PR TITLE
fix: renamed to CodeBase#AddLocalConnCfg to make it public

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go CI
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ '*', '*/*' ]
 
 jobs:
 

--- a/conn.go
+++ b/conn.go
@@ -88,7 +88,9 @@ func NewConnBase() *ConnBase {
 	}
 }
 
-func (base *ConnBase) addLocalConnCfg(name string, cfg ConnCfg) {
+// AddLocalConnCfg is a method which registers a local ConnCfg with a specified
+// name.
+func (base *ConnBase) AddLocalConnCfg(name string, cfg ConnCfg) {
 	base.connMutex.Lock()
 	defer base.connMutex.Unlock()
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -140,7 +140,7 @@ func TestNewConnBase(t *testing.T) {
 	assert.Equal(t, len(base.connMap), 0)
 }
 
-func TestConnBase_addLocalConnCfg(t *testing.T) {
+func TestConnBase_AddLocalConnCfg(t *testing.T) {
 	Clear()
 	defer Clear()
 
@@ -150,13 +150,13 @@ func TestConnBase_addLocalConnCfg(t *testing.T) {
 	assert.Equal(t, len(base.localConnCfgMap), 0)
 	assert.Equal(t, len(base.connMap), 0)
 
-	base.addLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
 
 	assert.False(t, base.isLocalConnCfgSealed)
 	assert.Equal(t, len(base.localConnCfgMap), 1)
 	assert.Equal(t, len(base.connMap), 0)
 
-	base.addLocalConnCfg("bar", &BarConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
 
 	assert.False(t, base.isLocalConnCfgSealed)
 	assert.Equal(t, len(base.localConnCfgMap), 2)
@@ -174,7 +174,7 @@ func TestConnBase_begin(t *testing.T) {
 	assert.Equal(t, len(base.localConnCfgMap), 0)
 	assert.Equal(t, len(base.connMap), 0)
 
-	base.addLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
 
 	assert.False(t, isGlobalConnCfgSealed)
 	assert.False(t, base.isLocalConnCfgSealed)
@@ -188,7 +188,7 @@ func TestConnBase_begin(t *testing.T) {
 	assert.Equal(t, len(base.localConnCfgMap), 1)
 	assert.Equal(t, len(base.connMap), 0)
 
-	base.addLocalConnCfg("bar", &BarConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
 
 	assert.True(t, isGlobalConnCfgSealed)
 	assert.True(t, base.isLocalConnCfgSealed)
@@ -197,7 +197,7 @@ func TestConnBase_begin(t *testing.T) {
 
 	base.isLocalConnCfgSealed = false
 
-	base.addLocalConnCfg("bar", &BarConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
 
 	assert.True(t, isGlobalConnCfgSealed)
 	assert.False(t, base.isLocalConnCfgSealed)
@@ -220,7 +220,7 @@ func TestConnBase_GetConn_withLocalConnCfg(t *testing.T) {
 		assert.Fail(t, err0.Error())
 	}
 
-	base.addLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
 
 	conn1, err1 := base.GetConn("foo")
 	assert.NotNil(t, conn1)
@@ -275,7 +275,7 @@ func TestConnBase_GetConn_localCfgIsTakenPriorityOfGlobalCfg(t *testing.T) {
 	AddGlobalConnCfg("foo", FooConnCfg{Label: "global"})
 	SealGlobalConnCfgs()
 
-	base.addLocalConnCfg("foo", FooConnCfg{Label: "local"})
+	base.AddLocalConnCfg("foo", FooConnCfg{Label: "local"})
 
 	conn, err = base.GetConn("foo")
 	assert.Equal(t, conn.(*FooConn).Label, "local")
@@ -290,7 +290,7 @@ func TestConnBase_GetConn_failToCreateConn(t *testing.T) {
 	defer func() { WillFailToCreateFooConn = false }()
 
 	base := NewConnBase()
-	base.addLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
 
 	conn, err := base.GetConn("foo")
 	assert.Nil(t, conn)
@@ -313,8 +313,8 @@ func TestConnBase_commit(t *testing.T) {
 
 	base := NewConnBase()
 
-	base.addLocalConnCfg("foo", FooConnCfg{})
-	base.addLocalConnCfg("bar", &BarConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
 	base.begin()
 
 	fooConn, fooErr := base.GetConn("foo")
@@ -344,8 +344,8 @@ func TestConnBase_commit_failed(t *testing.T) {
 
 	base := NewConnBase()
 
-	base.addLocalConnCfg("foo", FooConnCfg{})
-	base.addLocalConnCfg("bar", &BarConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
 	base.begin()
 
 	fooConn, fooErr := base.GetConn("foo")
@@ -378,8 +378,8 @@ func TestConnBase_rollback(t *testing.T) {
 
 	base := NewConnBase()
 
-	base.addLocalConnCfg("foo", FooConnCfg{})
-	base.addLocalConnCfg("bar", &BarConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
 	base.begin()
 
 	fooConn, fooErr := base.GetConn("foo")
@@ -408,8 +408,8 @@ func TestConnBase_close(t *testing.T) {
 
 	base := NewConnBase()
 
-	base.addLocalConnCfg("foo", FooConnCfg{})
-	base.addLocalConnCfg("bar", &BarConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
 	base.begin()
 
 	fooConn, fooErr := base.GetConn("foo")

--- a/dax_test.go
+++ b/dax_test.go
@@ -43,8 +43,8 @@ func TestDax_GetXxxConn(t *testing.T) {
 	defer Clear()
 
 	base := NewConnBase()
-	base.addLocalConnCfg("foo", FooConnCfg{})
-	base.addLocalConnCfg("bar", &BarConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
 	base.begin()
 
 	fooDax := NewFooDax(base)

--- a/proc.go
+++ b/proc.go
@@ -18,7 +18,7 @@ func NewProc[D any](connBase *ConnBase, dax D) Proc[D] {
 // AddLocalConnCfg is a method which registers a procedure-local ConnCfg
 // with a specified name.
 func (proc Proc[D]) AddLocalConnCfg(name string, cfg ConnCfg) {
-	proc.connBase.addLocalConnCfg(name, cfg)
+	proc.connBase.AddLocalConnCfg(name, cfg)
 }
 
 // RunTxn is a method which runs logic functions specified as arguments in a


### PR DESCRIPTION
This PR renames `CodeBase#[a]ddLocalConnCfg` to `#[A]ddLocalConnCfg` to make the method public.
This modification makes it possible to add local `ConnCfg` with not `Proc` but `CodeBase` in Dax unit tests