### PR TITLE
cicd: added go1.19 to target versions of ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gover: [1.18]
+        gover: [1.18, 1.19]
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
T/O