### PR TITLE
fix: added check of Conn existence in exclusive control codes

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -121,6 +121,11 @@ func (base *ConnBase) GetConn(name string) (Conn, Err) {
 	base.connMutex.Lock()
 	defer base.connMutex.Unlock()
 
+	conn = base.connMap[name]
+	if conn != nil {
+		return conn, Ok()
+	}
+
 	var err Err
 	conn, err = cfg.CreateConn()
 	if !err.IsOk() {

--- a/conn_test.go
+++ b/conn_test.go
@@ -116,7 +116,7 @@ func TestSealGlobalConnCfgs(t *testing.T) {
 	assert.True(t, isGlobalConnCfgSealed)
 	assert.Equal(t, len(globalConnCfgMap), 1)
 
-	AddGlobalConnCfg("foo", FooConnCfg{})
+	AddGlobalConnCfg("bar", BarConnCfg{})
 
 	assert.True(t, isGlobalConnCfgSealed)
 	assert.Equal(t, len(globalConnCfgMap), 1)


### PR DESCRIPTION
This PR adds a check of `Conn` existence before putting it to `connMap` in exclusive control codes.

 