### PR TITLE
fix: changed map key type of FailToRunInParallel.errors to int, etc.

### DIFF
--- a/dax.go
+++ b/dax.go
@@ -18,14 +18,14 @@ type /* error reasons */ (
 
 	// FailToCreateDaxConn is an error reason which indicates that it failed to
 	// create a new connection to a data source.
-	// The field Name is a registered name of DataSrc which failed to create a
+	// The field Name is a registered name of a DaxSrc which failed to create a
 	// DaxConn.
 	FailToCreateDaxConn struct {
 		Name string
 	}
 
 	// FailToCommitDaxConn is an error reason interface which indicates that some
-	// connection failed to commit.
+	// connections failed to commit.
 	// The field Errors is a map of which keys are registered names of DaxConn
 	// which failed to commit, and of which values are Err instances holding
 	// their error reasons.
@@ -73,13 +73,13 @@ func AddGlobalDaxSrc(name string, ds DaxSrc) {
 	}
 }
 
-// FixGlobalDaxSrc makes unable to register any further global DaxSrc.
+// FixGlobalDaxSrcs makes unable to register any further global DaxSrc.
 func FixGlobalDaxSrcs() {
 	isGlobalDaxSrcsFixed = true
 }
 
-// DaxBase is a structure type which manages multiple DaxSrc and DaxConn, and
-// also work as an implementation of Dax interface.
+// DaxBase is a structure type which manages multiple DaxSrc and those DaxConn,
+// and also work as an implementation of Dax interface.
 type DaxBase struct {
 	isLocalDaxSrcsFixed bool
 	localDaxSrcMap      map[string]DaxSrc
@@ -108,8 +108,9 @@ func (base *DaxBase) AddLocalDaxSrc(name string, ds DaxSrc) {
 }
 
 // GetDaxConn gets a DaxConn which is a connection to a data source by
-// specified name. If a DaxConn is found, this method creates new one with a
-// local or global DaxSrc associated with same name.
+// specified name.
+// If a DaxConn is found, this method returns it, but not found, creates a new
+// one with a local or global DaxSrc associated with same name.
 // If there are both local and global DaxSrc with same name, the local DaxSrc
 // is used.
 func (base *DaxBase) GetDaxConn(name string) (DaxConn, Err) {

--- a/dax_test.go
+++ b/dax_test.go
@@ -138,7 +138,7 @@ func TestFixGlobalDaxSrcs(t *testing.T) {
 	assert.Equal(t, len(globalDaxSrcMap), 2)
 }
 
-func TestNewDaxBase(t *testing.T) {
+func TestDaxBase_AddLocalDaxSrc(t *testing.T) {
 	Clear()
 	defer Clear()
 
@@ -169,13 +169,16 @@ func TestDaxBase_begin(t *testing.T) {
 
 	assert.False(t, isGlobalDaxSrcsFixed)
 	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 0)
 	assert.Equal(t, len(base.localDaxSrcMap), 0)
 	assert.Equal(t, len(base.daxConnMap), 0)
 
+	AddGlobalDaxSrc("foo", FooDaxSrc{})
 	base.AddLocalDaxSrc("foo", FooDaxSrc{})
 
 	assert.False(t, isGlobalDaxSrcsFixed)
 	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
 	assert.Equal(t, len(base.localDaxSrcMap), 1)
 	assert.Equal(t, len(base.daxConnMap), 0)
 
@@ -183,13 +186,16 @@ func TestDaxBase_begin(t *testing.T) {
 
 	assert.True(t, isGlobalDaxSrcsFixed)
 	assert.True(t, base.isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
 	assert.Equal(t, len(base.localDaxSrcMap), 1)
 	assert.Equal(t, len(base.daxConnMap), 0)
 
+	AddGlobalDaxSrc("bar", &BarDaxSrc{})
 	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
 
 	assert.True(t, isGlobalDaxSrcsFixed)
 	assert.True(t, base.isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
 	assert.Equal(t, len(base.localDaxSrcMap), 1)
 	assert.Equal(t, len(base.daxConnMap), 0)
 
@@ -197,13 +203,32 @@ func TestDaxBase_begin(t *testing.T) {
 
 	assert.True(t, isGlobalDaxSrcsFixed)
 	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
 	assert.Equal(t, len(base.localDaxSrcMap), 1)
 	assert.Equal(t, len(base.daxConnMap), 0)
 
+	AddGlobalDaxSrc("bar", &BarDaxSrc{})
 	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
 
 	assert.True(t, isGlobalDaxSrcsFixed)
 	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+	assert.Equal(t, len(base.localDaxSrcMap), 2)
+	assert.Equal(t, len(base.daxConnMap), 0)
+
+	isGlobalDaxSrcsFixed = false
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+	assert.Equal(t, len(base.localDaxSrcMap), 2)
+	assert.Equal(t, len(base.daxConnMap), 0)
+
+	AddGlobalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 2)
 	assert.Equal(t, len(base.localDaxSrcMap), 2)
 	assert.Equal(t, len(base.daxConnMap), 0)
 }

--- a/doc.go
+++ b/doc.go
@@ -29,7 +29,7 @@ For example, Greet is a logic and GreetDax is a dax interface:
     }
 
 In Greet function, there are no detail codes for getting name and putting greeting.
-In this logic function, it's only concern to convert a name to a greeting. 
+In this logic function, it's only concern to convert a name to a greeting.
 
 Dax for unit tests
 
@@ -41,7 +41,7 @@ The following code is an example which implements two methods: GetName and Say w
   }
 
   type (
-    NoName struct {}, // An error reason when getting no name. 
+    NoName struct {}, // An error reason when getting no name.
   )
 
   func (dax mapDax) GetName() (string, sabi.Err) {

--- a/runner.go
+++ b/runner.go
@@ -4,15 +4,11 @@
 
 package sabi
 
-import (
-	"strconv"
-)
-
 type /* error reasons */ (
 	// FailToRunInParallel is an error reason which indicates some runner which
 	// is runned in parallel failed.
 	FailToRunInParallel struct {
-		Errors map[string]Err
+		Errors map[int]Err
 	}
 )
 
@@ -56,13 +52,13 @@ func (r paraRunner) Run() Err {
 		}(runner, ch)
 	}
 
-	errs := make(map[string]Err)
+	errs := make(map[int]Err)
 	n := len(r.runners)
 	for i := 0; i < n; i++ {
 		select {
 		case err := <-ch:
 			if !err.IsOk() {
-				errs[strconv.Itoa(i)] = err
+				errs[i] = err
 			}
 		}
 	}
@@ -102,13 +98,13 @@ func RunPara(runners ...Runner) Err {
 		}(runner, ch)
 	}
 
-	errs := make(map[string]Err)
+	errs := make(map[int]Err)
 	n := len(runners)
 	for i := 0; i < n; i++ {
 		select {
 		case err := <-ch:
 			if !err.IsOk() {
-				errs[strconv.Itoa(i)] = err
+				errs[i] = err
 			}
 		}
 	}

--- a/runner.go
+++ b/runner.go
@@ -9,7 +9,7 @@ import (
 )
 
 type /* error reasons */ (
-	// FailToRunInParallel is a error reason which indicates some runner which
+	// FailToRunInParallel is an error reason which indicates some runner which
 	// is runned in parallel failed.
 	FailToRunInParallel struct {
 		Errors map[string]Err

--- a/runner_test.go
+++ b/runner_test.go
@@ -111,9 +111,9 @@ func TestPara_FailToRun(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case sabi.FailToRunInParallel:
-		errs := err.Get("Errors").(map[string]sabi.Err)
+		errs := err.Get("Errors").(map[int]sabi.Err)
 		assert.Equal(t, len(errs), 1)
-		assert.Equal(t, errs["0"].Error(), "{reason=FailToRun, Name=r-1}")
+		assert.Equal(t, errs[0].Error(), "{reason=FailToRun, Name=r-1}")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -196,9 +196,9 @@ func TestRunPara_FailToRun(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case sabi.FailToRunInParallel:
-		errs := err.Get("Errors").(map[string]sabi.Err)
+		errs := err.Get("Errors").(map[int]sabi.Err)
 		assert.Equal(t, len(errs), 1)
-		assert.Equal(t, errs["0"].Error(), "{reason=FailToRun, Name=r-1}")
+		assert.Equal(t, errs[0].Error(), "{reason=FailToRun, Name=r-1}")
 	default:
 		assert.Fail(t, err.Error())
 	}


### PR DESCRIPTION
### Changes:

1. [comment: modified some comments.](https://github.com/sttk-go/sabi/commit/48a97556e1d0dd0a7011f38e9fa1dd2aff330a56)

    Some mistakes in source codes' comments are modified.

3. [test: added assertsions in dax test](https://github.com/sttk-go/sabi/commit/e92fa7860fc88742dccb701fff4ffb6ac6cd9c08)

    Assertions for global `DaxSrc`s in test cases of `TestDaxBase_begin` are added.
    And the test case `TestNewDaxBase` is renamed to `TestDaxBase_AddLocalDaxSrc`.

4. [doc: removed spaces at eols in doc.go](https://github.com/sttk-go/sabi/commit/b7907b30643a86398d4adb43c971c1749a9400f2)

    Since there are two lines which have a space at end of line, those spaces are removed.

5. [fix: changed map key type of FailToRunInParallel.errors to int](https://github.com/sttk-go/sabi/commit/48b0503c0be85e1ce2e8ff06d3dd2ab760be275a)

    `FailToRunInParallel.errors` was a map of which key type is `string` and value type is `sabi.Err`. But that key is index of a runner. So the key type is changed to `int`.