### PR TITLE
Modify mistakes of comments, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This framework supports Go 1.18 or later.
 <a name="license"></a>
 ## License
 
-Copyright (C) 2022 Takayuki Sato
+Copyright (C) 2022-2023 Takayuki Sato
 
 This program is free software under MIT License.<br>
 See the file LICENSE in this distribution for more details.

--- a/dax.go
+++ b/dax.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2022-2023 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
@@ -51,7 +51,7 @@ type DaxSrc interface {
 }
 
 // Dax is an interface for a set of data accesses, and requires a method:
-// #GetConn which gets a connection to an external data access.
+// #GetDaxConn which gets a connection to an external data access.
 type Dax interface {
 	GetDaxConn(name string) (DaxConn, Err)
 }

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 Takayuki Sato. All Rights Reserved.
+// Copyright (C) 2022-2023 Takayuki Sato. All Rights Reserved.
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 

--- a/doc.go
+++ b/doc.go
@@ -102,7 +102,7 @@ This dax accesses to a database and provides an implementation of GetName method
 
   type (
     FailToCreateStmt struct {}
-    NoUser struct { id string }
+    NoUser struct {}
     FailToQueryUserName struct {}
   )
 
@@ -121,7 +121,7 @@ This dax accesses to a database and provides an implementation of GetName method
     err = stmt.QueryRow().Scan(&username)
     switch {
     case err == sql.ErrNoRows:
-      return "", sabi.ErrBy(NoUser{id: id})
+      return "", sabi.ErrBy(NoUser{})
     case err != nil:
       return "", sabi.ErrBy(FailToQueryUserName{})
     default:


### PR DESCRIPTION
### Changes:

1. [doc: modified mistakes in doc.go](https://github.com/sttk-go/sabi/commit/ef9595b51b45c7abbdd2eca90b613be8fa2cf6a8)

    This commit modifies mistakes of comments in `doc.go`.

2. [doc: updated license year](https://github.com/sttk-go/sabi/commit/82a9f7d94f273dd3835c0ba70e52bc2ebf98d76f)

    This commit updates license years in `README.md` and `doc.go` so as to include this year.

3. [comment: modified a mistake of the comment of Dax interface.](https://github.com/sttk-go/sabi/commit/3033b60315717749e6ecc7f342d21b8cad3d24f1)

    This commit modifies a mistake of a comment in `dax.go`.