### PR TITLE
update: renamed `ErrBy` function to `NewErr`

### DIFF
--- a/benchmark_err_test.go
+++ b/benchmark_err_test.go
@@ -17,22 +17,22 @@ type /* error reason */ (
 func _err_unused(v interface{}) {
 }
 
-func BenchmarkErr_ErrBy_empty(b *testing.B) {
+func BenchmarkErr_NewErr_empty(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := sabi.ErrBy(ReasonForBenchWithNoParam{})
+		err := sabi.NewErr(ReasonForBenchWithNoParam{})
 		_err_unused(err)
 	}
 
 	b.StopTimer()
 }
 
-func BenchmarkErr_ErrBy_manyParams(b *testing.B) {
+func BenchmarkErr_NewErr_manyParams(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := sabi.ErrBy(ReasonForBenchWithManyParams{
+		err := sabi.NewErr(ReasonForBenchWithManyParams{
 			Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 			Param2:  "abcdefghijklmnopqrstuvwxyz",
 			Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
@@ -51,7 +51,7 @@ func BenchmarkErr_ErrBy_manyParams(b *testing.B) {
 }
 
 func ProcForBenchByVal() sabi.Err {
-	err := sabi.ErrBy(ReasonForBenchWithManyParams{
+	err := sabi.NewErr(ReasonForBenchWithManyParams{
 		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 		Param2:  "abcdefghijklmnopqrstuvwxyz",
 		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
@@ -66,7 +66,7 @@ func ProcForBenchByVal() sabi.Err {
 	return err
 }
 
-func BenchmarkErr_ErrBy_byValue(b *testing.B) {
+func BenchmarkErr_NewErr_byValue(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -78,7 +78,7 @@ func BenchmarkErr_ErrBy_byValue(b *testing.B) {
 }
 
 func ProcForBenchByPtr() *sabi.Err {
-	err := sabi.ErrBy(ReasonForBenchWithManyParams{
+	err := sabi.NewErr(ReasonForBenchWithManyParams{
 		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 		Param2:  "abcdefghijklmnopqrstuvwxyz",
 		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
@@ -93,7 +93,7 @@ func ProcForBenchByPtr() *sabi.Err {
 	return &err
 }
 
-func BenchmarkErr_ErrBy_byPtr(b *testing.B) {
+func BenchmarkErr_NewErr_byPtr(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -105,7 +105,7 @@ func BenchmarkErr_ErrBy_byPtr(b *testing.B) {
 }
 
 func BenchmarkErr_Reason_emtpy(b *testing.B) {
-	err := sabi.ErrBy(ReasonForBenchWithNoParam{})
+	err := sabi.NewErr(ReasonForBenchWithNoParam{})
 
 	b.StartTimer()
 
@@ -118,7 +118,7 @@ func BenchmarkErr_Reason_emtpy(b *testing.B) {
 }
 
 func BenchmarkErr_Reason_manyParams(b *testing.B) {
-	err := sabi.ErrBy(ReasonForBenchWithManyParams{
+	err := sabi.NewErr(ReasonForBenchWithManyParams{
 		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 		Param2:  "abcdefghijklmnopqrstuvwxyz",
 		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
@@ -142,7 +142,7 @@ func BenchmarkErr_Reason_manyParams(b *testing.B) {
 }
 
 func BenchmarkErr_Reason_type_emtpy(b *testing.B) {
-	err := sabi.ErrBy(ReasonForBenchWithNoParam{})
+	err := sabi.NewErr(ReasonForBenchWithNoParam{})
 
 	b.StartTimer()
 
@@ -156,7 +156,7 @@ func BenchmarkErr_Reason_type_emtpy(b *testing.B) {
 }
 
 func BenchmarkErr_Reason_type_manyParams(b *testing.B) {
-	err := sabi.ErrBy(ReasonForBenchWithManyParams{
+	err := sabi.NewErr(ReasonForBenchWithManyParams{
 		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 		Param2:  "abcdefghijklmnopqrstuvwxyz",
 		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
@@ -181,7 +181,7 @@ func BenchmarkErr_Reason_type_manyParams(b *testing.B) {
 }
 
 func BenchmarkErr_ReasonName(b *testing.B) {
-	err := sabi.ErrBy(ReasonForBenchWithManyParams{
+	err := sabi.NewErr(ReasonForBenchWithManyParams{
 		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 		Param2:  "abcdefghijklmnopqrstuvwxyz",
 		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
@@ -206,7 +206,7 @@ func BenchmarkErr_ReasonName(b *testing.B) {
 
 func BenchmarkErr_Cause(b *testing.B) {
 	cause := errors.New("Causal error")
-	err := sabi.ErrBy(ReasonForBenchWithManyParams{
+	err := sabi.NewErr(ReasonForBenchWithManyParams{
 		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 		Param2:  "abcdefghijklmnopqrstuvwxyz",
 		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
@@ -230,7 +230,7 @@ func BenchmarkErr_Cause(b *testing.B) {
 }
 
 func BenchmarkErr_Situation(b *testing.B) {
-	err := sabi.ErrBy(ReasonForBenchWithManyParams{
+	err := sabi.NewErr(ReasonForBenchWithManyParams{
 		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 		Param2:  "abcdefghijklmnopqrstuvwxyz",
 		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
@@ -254,7 +254,7 @@ func BenchmarkErr_Situation(b *testing.B) {
 }
 
 func BenchmarkErr_Get(b *testing.B) {
-	err := sabi.ErrBy(ReasonForBenchWithManyParams{
+	err := sabi.NewErr(ReasonForBenchWithManyParams{
 		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 		Param2:  "abcdefghijklmnopqrstuvwxyz",
 		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",

--- a/dax.go
+++ b/dax.go
@@ -124,7 +124,7 @@ func (base *DaxBase) GetDaxConn(name string) (DaxConn, Err) {
 		ds = globalDaxSrcMap[name]
 	}
 	if ds == nil {
-		return nil, ErrBy(DaxSrcIsNotFound{Name: name})
+		return nil, NewErr(DaxSrcIsNotFound{Name: name})
 	}
 
 	base.daxConnMutex.Lock()
@@ -138,7 +138,7 @@ func (base *DaxBase) GetDaxConn(name string) (DaxConn, Err) {
 	var err Err
 	conn, err = ds.CreateDaxConn()
 	if !err.IsOk() {
-		return nil, ErrBy(FailToCreateDaxConn{Name: name}, err)
+		return nil, NewErr(FailToCreateDaxConn{Name: name}, err)
 	}
 
 	base.daxConnMap[name] = conn
@@ -179,7 +179,7 @@ func (base *DaxBase) commit() Err {
 	}
 
 	if len(errs) > 0 {
-		return ErrBy(FailToCommitDaxConn{Errors: errs})
+		return NewErr(FailToCommitDaxConn{Errors: errs})
 	}
 
 	return Ok()

--- a/dax_test.go
+++ b/dax_test.go
@@ -31,7 +31,7 @@ type FooDaxConn struct {
 
 func (conn *FooDaxConn) Commit() Err {
 	if WillFailToCommitFooDaxConn {
-		return ErrBy(InvalidDaxConn{})
+		return NewErr(InvalidDaxConn{})
 	}
 	logs.PushBack("FooDaxConn#Commit")
 	return Ok()
@@ -51,7 +51,7 @@ type FooDaxSrc struct {
 
 func (ds FooDaxSrc) CreateDaxConn() (DaxConn, Err) {
 	if WillFailToCreateFooDaxConn {
-		return nil, ErrBy(InvalidDaxConn{})
+		return nil, NewErr(InvalidDaxConn{})
 	}
 	return &FooDaxConn{Label: ds.Label}, Ok()
 }

--- a/doc.go
+++ b/doc.go
@@ -47,7 +47,7 @@ The following code is an example which implements two methods: GetName and Say w
 	func (dax mapDax) GetName() (string, sabi.Err) {
 	  name, exists := dax.m["name"]
 	  if !exists {
-	    return "", sabi.ErrBy(NoName{})
+	    return "", sabi.NewErr(NoName{})
 	  }
 	  return name, sabi.Ok()
 	}
@@ -88,7 +88,7 @@ This dax outputs a greeting to standard output.
 	func (dax SayConsoleDax) Say(text string) sabi.Err {
 	  _, e := fmt.Println(text)
 	  if e != nil {
-	    return sabi.ErrBy(FailToPrint{}, e)
+	    return sabi.NewErr(FailToPrint{}, e)
 	  }
 	  return sabi.Ok()
 	}
@@ -113,7 +113,7 @@ This dax accesses to a database and provides an implementation of GetName method
 	  }
 	  stmt, err := conn.Prepare("SELECT username FROM users LIMIT 1")
 	  if err != nil {
-	    return "", sabi.ErrBy(FailToCreateStmt{})
+	    return "", sabi.NewErr(FailToCreateStmt{})
 	  }
 	  defer stmt.Close()
 
@@ -121,9 +121,9 @@ This dax accesses to a database and provides an implementation of GetName method
 	  err = stmt.QueryRow().Scan(&username)
 	  switch {
 	  case err == sql.ErrNoRows:
-	    return "", sabi.ErrBy(NoUser{})
+	    return "", sabi.NewErr(NoUser{})
 	  case err != nil:
-	    return "", sabi.ErrBy(FailToQueryUserName{})
+	    return "", sabi.NewErr(FailToQueryUserName{})
 	  default:
 	    return username, sabi.Ok()
 	  }

--- a/err.go
+++ b/err.go
@@ -29,9 +29,9 @@ func Ok() Err {
 	return ok
 }
 
-// ErrBy is a function which creates a new Err value with a reason and a cause.
+// NewErr is a function which creates a new Err value with a reason and a cause.
 // A reason is a structure type of which name expresses what is a reason.
-func ErrBy(reason any, cause ...error) Err {
+func NewErr(reason any, cause ...error) Err {
 	var err Err
 	err.reason = reason
 

--- a/err_test.go
+++ b/err_test.go
@@ -16,8 +16,8 @@ type /* error reasons */ (
 	}
 )
 
-func TestErrBy_reasonIsValue(t *testing.T) {
-	err := sabi.ErrBy(InvalidValue{Value: "abc"})
+func TestNewErr_reasonIsValue(t *testing.T) {
+	err := sabi.NewErr(InvalidValue{Value: "abc"})
 
 	assert.Equal(t, err.Error(), "{reason=InvalidValue, Value=abc}")
 	assert.Equal(t, err.FileName(), "err_test.go")
@@ -45,8 +45,8 @@ func TestErrBy_reasonIsValue(t *testing.T) {
 	assert.Nil(t, err.Unwrap())
 }
 
-func TestErrBy_reasonIsPointer(t *testing.T) {
-	err := sabi.ErrBy(&InvalidValue{Value: "abc"})
+func TestNewErr_reasonIsPointer(t *testing.T) {
+	err := sabi.NewErr(&InvalidValue{Value: "abc"})
 
 	assert.Equal(t, err.Error(), "{reason=InvalidValue, Value=abc}")
 	assert.Equal(t, err.FileName(), "err_test.go")
@@ -74,9 +74,9 @@ func TestErrBy_reasonIsPointer(t *testing.T) {
 	assert.Nil(t, err.Unwrap())
 }
 
-func TestErrBy_withCause(t *testing.T) {
+func TestNewErr_withCause(t *testing.T) {
 	cause := errors.New("def")
-	err := sabi.ErrBy(InvalidValue{Value: "abc"}, cause)
+	err := sabi.NewErr(InvalidValue{Value: "abc"}, cause)
 
 	assert.Equal(t, err.Error(), "{reason=InvalidValue, Value=abc, cause=def}")
 	assert.Equal(t, err.FileName(), "err_test.go")
@@ -104,9 +104,9 @@ func TestErrBy_withCause(t *testing.T) {
 	assert.Equal(t, errors.Unwrap(err), cause)
 }
 
-func TestErrBy_causeIsAlsoErr(t *testing.T) {
-	cause := sabi.ErrBy(FailToGetValue{Name: "foo"})
-	err := sabi.ErrBy(InvalidValue{Value: "abc"}, cause)
+func TestNewErr_causeIsAlsoErr(t *testing.T) {
+	cause := sabi.NewErr(FailToGetValue{Name: "foo"})
+	err := sabi.NewErr(InvalidValue{Value: "abc"}, cause)
 
 	assert.Equal(t, err.Error(), "{reason=InvalidValue, Value=abc, cause={reason=FailToGetValue, Name=foo}}")
 	assert.Equal(t, err.FileName(), "err_test.go")

--- a/example_err_test.go
+++ b/example_err_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sttk-go/sabi"
 )
 
-func ExampleErrBy() {
+func ExampleNewErr() {
 	type /* error reason */ (
 		FailToDoSomething           struct{}
 		FailToDoSomethingWithParams struct {
@@ -16,11 +16,11 @@ func ExampleErrBy() {
 	)
 
 	// (1) Creates an Err with no situation parameter.
-	err := sabi.ErrBy(FailToDoSomething{})
+	err := sabi.NewErr(FailToDoSomething{})
 	fmt.Printf("(1) %v\n", err)
 
 	// (2) Creates an Err with situation parameters.
-	err = sabi.ErrBy(FailToDoSomethingWithParams{
+	err = sabi.NewErr(FailToDoSomethingWithParams{
 		Param1: "ABC",
 		Param2: 123,
 	})
@@ -29,11 +29,11 @@ func ExampleErrBy() {
 	cause := errors.New("Causal error")
 
 	// (3) Creates an Err with a causal error.
-	err = sabi.ErrBy(FailToDoSomething{}, cause)
+	err = sabi.NewErr(FailToDoSomething{}, cause)
 	fmt.Printf("(3) %v\n", err)
 
 	// (4) Creates an Err with situation parameters and a causal error.
-	err = sabi.ErrBy(FailToDoSomethingWithParams{
+	err = sabi.NewErr(FailToDoSomethingWithParams{
 		Param1: "ABC",
 		Param2: 123,
 	}, cause)
@@ -61,7 +61,7 @@ func ExampleErr_Cause() {
 
 	cause := errors.New("Causal error")
 
-	err := sabi.ErrBy(FailToDoSomething{}, cause)
+	err := sabi.NewErr(FailToDoSomething{}, cause)
 	fmt.Printf("%v\n", err.Cause())
 
 	// Output:
@@ -76,7 +76,7 @@ func ExampleErr_Error() {
 
 	cause := errors.New("Causal error")
 
-	err := sabi.ErrBy(FailToDoSomething{
+	err := sabi.NewErr(FailToDoSomething{
 		Param1: "ABC",
 		Param2: 123,
 	}, cause)
@@ -89,7 +89,7 @@ func ExampleErr_Error() {
 func ExampleErr_FileName() {
 	type FailToDoSomething struct{}
 
-	err := sabi.ErrBy(FailToDoSomething{})
+	err := sabi.NewErr(FailToDoSomething{})
 	fmt.Printf("%v\n", err.FileName())
 
 	// Output:
@@ -102,7 +102,7 @@ func ExampleErr_Get() {
 		Param2 int
 	}
 
-	err := sabi.ErrBy(FailToDoSomething{
+	err := sabi.NewErr(FailToDoSomething{
 		Param1: "ABC",
 		Param2: 123,
 	})
@@ -121,7 +121,7 @@ func ExampleErr_IsOk() {
 	fmt.Printf("%v\n", err.IsOk())
 
 	type FailToDoSomething struct{}
-	err = sabi.ErrBy(FailToDoSomething{})
+	err = sabi.NewErr(FailToDoSomething{})
 	fmt.Printf("%v\n", err.IsOk())
 
 	// Output:
@@ -132,7 +132,7 @@ func ExampleErr_IsOk() {
 func ExampleErr_LineNumber() {
 	type FailToDoSomething struct{}
 
-	err := sabi.ErrBy(FailToDoSomething{})
+	err := sabi.NewErr(FailToDoSomething{})
 	fmt.Printf("%v\n", err.LineNumber())
 
 	// Output:
@@ -144,7 +144,7 @@ func ExampleErr_Reason() {
 		Param1 string
 	}
 
-	err := sabi.ErrBy(FailToDoSomething{Param1: "value1"})
+	err := sabi.NewErr(FailToDoSomething{Param1: "value1"})
 	switch err.Reason().(type) {
 	case FailToDoSomething:
 		fmt.Println("The reason of the error is: FailToDoSomething")
@@ -152,7 +152,7 @@ func ExampleErr_Reason() {
 		fmt.Printf("The value of reason.Param1 is: %v\n", reason.Param1)
 	}
 
-	err = sabi.ErrBy(&FailToDoSomething{Param1: "value2"})
+	err = sabi.NewErr(&FailToDoSomething{Param1: "value2"})
 	switch err.Reason().(type) {
 	case *FailToDoSomething:
 		fmt.Println("The reason of the error is: *FailToDoSomething")
@@ -170,7 +170,7 @@ func ExampleErr_Reason() {
 func ExampleErr_ReasonName() {
 	type FailToDoSomething struct{}
 
-	err := sabi.ErrBy(FailToDoSomething{})
+	err := sabi.NewErr(FailToDoSomething{})
 	fmt.Printf("%v\n", err.ReasonName())
 
 	// Output:
@@ -180,7 +180,7 @@ func ExampleErr_ReasonName() {
 func ExampleErr_ReasonPackage() {
 	type FailToDoSomething struct{}
 
-	err := sabi.ErrBy(FailToDoSomething{})
+	err := sabi.NewErr(FailToDoSomething{})
 	fmt.Printf("%v\n", err.ReasonPackage())
 
 	// Output:
@@ -193,7 +193,7 @@ func ExampleErr_Situation() {
 		Param2 int
 	}
 
-	err := sabi.ErrBy(FailToDoSomething{
+	err := sabi.NewErr(FailToDoSomething{
 		Param1: "ABC",
 		Param2: 123,
 	})
@@ -209,7 +209,7 @@ func ExampleErr_Unwrap() {
 	cause1 := errors.New("Causal error 1")
 	cause2 := errors.New("Causal error 2")
 
-	err := sabi.ErrBy(FailToDoSomething{}, cause1)
+	err := sabi.NewErr(FailToDoSomething{}, cause1)
 
 	fmt.Printf("err.Unwrap() = %v\n", err.Unwrap())
 	fmt.Printf("errors.Is(err, cause1) = %v\n", errors.Is(err, cause1))

--- a/example_notify_test.go
+++ b/example_notify_test.go
@@ -14,7 +14,7 @@ func ExampleAddAsyncErrHandler() {
 
 	type FailToDoSomething struct{ Name string }
 
-	sabi.ErrBy(FailToDoSomething{Name: "abc"})
+	sabi.NewErr(FailToDoSomething{Name: "abc"})
 
 	// Output:
 	// Asynchronous error handling: {reason=FailToDoSomething, Name=abc}
@@ -31,7 +31,7 @@ func ExampleAddSyncErrHandler() {
 
 	type FailToDoSomething struct{ Name string }
 
-	sabi.ErrBy(FailToDoSomething{Name: "abc"})
+	sabi.NewErr(FailToDoSomething{Name: "abc"})
 
 	// Output:
 	// Synchronous error handling: {reason=FailToDoSomething, Name=abc}
@@ -52,7 +52,7 @@ func ExampleFixErrCfgs() {
 
 	type FailToDoSomething struct{ Name string }
 
-	sabi.ErrBy(FailToDoSomething{Name: "abc"})
+	sabi.NewErr(FailToDoSomething{Name: "abc"})
 
 	// Output:
 	// This handler is registered

--- a/notify_test.go
+++ b/notify_test.go
@@ -151,7 +151,7 @@ func TestNotifyErr_withNoErrHandler(t *testing.T) {
 	ClearErrHandlers()
 	defer ClearErrHandlers()
 
-	ErrBy(ReasonForNotification{})
+	NewErr(ReasonForNotification{})
 
 	assert.False(t, isErrCfgsFixed)
 
@@ -159,7 +159,7 @@ func TestNotifyErr_withNoErrHandler(t *testing.T) {
 
 	assert.True(t, isErrCfgsFixed)
 
-	ErrBy(ReasonForNotification{})
+	NewErr(ReasonForNotification{})
 }
 
 func TestNotifyErr_withHandlers(t *testing.T) {
@@ -179,7 +179,7 @@ func TestNotifyErr_withHandlers(t *testing.T) {
 		asyncLogs.PushBack(err.ReasonName() + "-3")
 	})
 
-	ErrBy(ReasonForNotification{})
+	NewErr(ReasonForNotification{})
 
 	assert.False(t, isErrCfgsFixed)
 
@@ -188,7 +188,7 @@ func TestNotifyErr_withHandlers(t *testing.T) {
 
 	FixErrCfgs()
 
-	ErrBy(ReasonForNotification{})
+	NewErr(ReasonForNotification{})
 
 	assert.True(t, isErrCfgsFixed)
 

--- a/runner.go
+++ b/runner.go
@@ -64,7 +64,7 @@ func (r paraRunner) Run() Err {
 	}
 
 	if len(errs) > 0 {
-		return ErrBy(FailToRunInParallel{Errors: errs})
+		return NewErr(FailToRunInParallel{Errors: errs})
 	}
 
 	return Ok()
@@ -110,7 +110,7 @@ func RunPara(runners ...Runner) Err {
 	}
 
 	if len(errs) > 0 {
-		return ErrBy(FailToRunInParallel{Errors: errs})
+		return NewErr(FailToRunInParallel{Errors: errs})
 	}
 
 	return Ok()

--- a/runner_test.go
+++ b/runner_test.go
@@ -30,7 +30,7 @@ type MyRunner struct {
 func (r MyRunner) Run() sabi.Err {
 	time.Sleep(r.Wait)
 	if r.Name == errorRunnerName {
-		return sabi.ErrBy(FailToRun{Name: r.Name})
+		return sabi.NewErr(FailToRun{Name: r.Name})
 	}
 	logs.PushBack(r.Name)
 	return sabi.Ok()


### PR DESCRIPTION
This PR renames `ErrBy` function to `NewErr` in order to conform to Go's constructor pattern, and makes the way of creation of an `Err` resemble sttk-go/java's sabi.