### PR TITLE
update!: changed DaxBase to interface and adds some modifications

### DIFF
--- a/dax.go
+++ b/dax.go
@@ -53,7 +53,7 @@ type DaxSrc interface {
 
 // Dax is an interface for a set of data access methods.
 // This interface defines a method: GetDaxConn.
-// This method gets a DaxConn which is a connection to a data source by
+// This method gets a DaxConn which is a connection to a data store by
 // specified name.
 // If a DaxConn is found, this method returns it, but not found, creates a new
 // one with a local or global DaxSrc associated with same name.
@@ -93,14 +93,14 @@ func FixGlobalDaxSrcs() {
 }
 
 // DaxBase is an interface which works as a front of an implementation as a
-// base of data sources, and defines methods: AddLocalDaxSrc and
+// base of data connection sources, and defines methods: AddLocalDaxSrc and
 // RemoveLocalDaxSrc.
 //
 // AddLocalDaxSrc method registered a DaxSrc with a name in this
 // implementation, but  ignores to add a local DaxSrc when its name is already
 // registered.
-// In addition, this method ignores to add any more local DaxSrc(s) while
-// the transaction is processing.
+// In addition, this method ignores to add local DaxSrc(s) while the
+// transaction is processing.
 //
 // This interface inherits Dax interface, so this has GetDaxConn method, too.
 // Also this has unexported methods for a transaction process.
@@ -121,8 +121,7 @@ type daxBaseImpl struct {
 	daxConnMutex        sync.Mutex
 }
 
-// NewDaxBase is a function which creates a new DaxBase instance and returns
-// its pointer.
+// NewDaxBase is a function which creates a new DaxBase.
 func NewDaxBase() DaxBase {
 	return &daxBaseImpl{
 		isLocalDaxSrcsFixed: false,

--- a/dax_test.go
+++ b/dax_test.go
@@ -144,21 +144,76 @@ func TestDaxBase_AddLocalDaxSrc(t *testing.T) {
 
 	base := NewDaxBase()
 
-	assert.False(t, base.isLocalDaxSrcsFixed)
-	assert.Equal(t, len(base.localDaxSrcMap), 0)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
 
 	base.AddLocalDaxSrc("foo", FooDaxSrc{})
 
-	assert.False(t, base.isLocalDaxSrcsFixed)
-	assert.Equal(t, len(base.localDaxSrcMap), 1)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.(*daxBaseImpl).isLocalDaxSrcsFixed = true
 
 	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
 
-	assert.False(t, base.isLocalDaxSrcsFixed)
-	assert.Equal(t, len(base.localDaxSrcMap), 2)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.True(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.(*daxBaseImpl).isLocalDaxSrcsFixed = false
+
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+}
+
+func TestDaxBase_RemoveLocalDaxSrc(t *testing.T) {
+	Clear()
+	defer Clear()
+
+	base := NewDaxBase()
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.RemoveLocalDaxSrc("bar")
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.(*daxBaseImpl).isLocalDaxSrcsFixed = true
+
+	base.RemoveLocalDaxSrc("foo")
+
+	assert.True(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.(*daxBaseImpl).isLocalDaxSrcsFixed = false
+
+	base.RemoveLocalDaxSrc("foo")
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
 }
 
 func TestDaxBase_begin(t *testing.T) {
@@ -168,69 +223,69 @@ func TestDaxBase_begin(t *testing.T) {
 	base := NewDaxBase()
 
 	assert.False(t, isGlobalDaxSrcsFixed)
-	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
 	assert.Equal(t, len(globalDaxSrcMap), 0)
-	assert.Equal(t, len(base.localDaxSrcMap), 0)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
 
 	AddGlobalDaxSrc("foo", FooDaxSrc{})
 	base.AddLocalDaxSrc("foo", FooDaxSrc{})
 
 	assert.False(t, isGlobalDaxSrcsFixed)
-	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
 	assert.Equal(t, len(globalDaxSrcMap), 1)
-	assert.Equal(t, len(base.localDaxSrcMap), 1)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
 
 	base.begin()
 
 	assert.True(t, isGlobalDaxSrcsFixed)
-	assert.True(t, base.isLocalDaxSrcsFixed)
+	assert.True(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
 	assert.Equal(t, len(globalDaxSrcMap), 1)
-	assert.Equal(t, len(base.localDaxSrcMap), 1)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
 
 	AddGlobalDaxSrc("bar", &BarDaxSrc{})
 	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
 
 	assert.True(t, isGlobalDaxSrcsFixed)
-	assert.True(t, base.isLocalDaxSrcsFixed)
+	assert.True(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
 	assert.Equal(t, len(globalDaxSrcMap), 1)
-	assert.Equal(t, len(base.localDaxSrcMap), 1)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
 
-	base.isLocalDaxSrcsFixed = false
+	base.(*daxBaseImpl).isLocalDaxSrcsFixed = false
 
 	assert.True(t, isGlobalDaxSrcsFixed)
-	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
 	assert.Equal(t, len(globalDaxSrcMap), 1)
-	assert.Equal(t, len(base.localDaxSrcMap), 1)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
 
 	AddGlobalDaxSrc("bar", &BarDaxSrc{})
 	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
 
 	assert.True(t, isGlobalDaxSrcsFixed)
-	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
 	assert.Equal(t, len(globalDaxSrcMap), 1)
-	assert.Equal(t, len(base.localDaxSrcMap), 2)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
 
 	isGlobalDaxSrcsFixed = false
 
 	assert.False(t, isGlobalDaxSrcsFixed)
-	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
 	assert.Equal(t, len(globalDaxSrcMap), 1)
-	assert.Equal(t, len(base.localDaxSrcMap), 2)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
 
 	AddGlobalDaxSrc("bar", &BarDaxSrc{})
 
 	assert.False(t, isGlobalDaxSrcsFixed)
-	assert.False(t, base.isLocalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
 	assert.Equal(t, len(globalDaxSrcMap), 2)
-	assert.Equal(t, len(base.localDaxSrcMap), 2)
-	assert.Equal(t, len(base.daxConnMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
 }
 
 func TestDaxBase_GetDaxConn_withLocalDaxSrc(t *testing.T) {
@@ -451,7 +506,7 @@ func TestDaxBase_close(t *testing.T) {
 	assert.NotNil(t, barConn)
 	assert.True(t, barErr.IsOk())
 
-	base.close()
+	base.end()
 
 	assert.Equal(t, logs.Len(), 2)
 	if logs.Front().Value == "FooDaxConn#Close" {

--- a/proc.go
+++ b/proc.go
@@ -6,12 +6,12 @@ package sabi
 
 // Proc is a structure type which represents a procedure.
 type Proc[D any] struct {
-	daxBase *DaxBase
+	daxBase DaxBase
 	dax     D
 }
 
 // NewProc is a function which create a new Proc.
-func NewProc[D any](daxBase *DaxBase, dax D) Proc[D] {
+func NewProc[D any](daxBase DaxBase, dax D) Proc[D] {
 	return Proc[D]{daxBase: daxBase, dax: dax}
 }
 
@@ -43,7 +43,7 @@ func (proc Proc[D]) RunTxn(logics ...func(dax D) Err) Err {
 		proc.daxBase.rollback()
 	}
 
-	proc.daxBase.close()
+	proc.daxBase.end()
 
 	return err
 }
@@ -60,7 +60,7 @@ func (proc Proc[D]) Txn(logics ...func(dax D) Err) Runner {
 
 type txnRunner[D any] struct {
 	logics  []func(D) Err
-	daxBase *DaxBase
+	daxBase DaxBase
 	dax     D
 }
 
@@ -84,7 +84,7 @@ func (txn txnRunner[D]) Run() Err {
 		txn.daxBase.rollback()
 	}
 
-	txn.daxBase.close()
+	txn.daxBase.end()
 
 	return err
 }


### PR DESCRIPTION
This PR changes `DaxBase` from a struct to an interface, because it makes enable type assertion of `DaxBase` to another `Dax` interface.

In addition, this PR adds/modifies `DaxBase` in the following points:

-  Adds `RemoveLocalDaxSrc` method so as to be able to remove a local `DaxSrc` finished using and wanted to unable to use in next transaction.

- Changes the method name of `close` to `end`.

- In `end` method (originally `close` method), adds renewal of `daxConnMap` which stores `DaxConn`(s) only while a transaction process. 


