### PR TITLE
perf!: removed file and line from Err and made them passed to error handler

### DIFF
--- a/benchmark_err_test.go
+++ b/benchmark_err_test.go
@@ -1,296 +1,589 @@
 package sabi_test
 
 import (
-	"errors"
 	"github.com/sttk-go/sabi"
+	"strconv"
 	"testing"
 )
 
-type /* error reason */ (
-	ReasonForBenchWithNoParam    struct{}
-	ReasonForBenchWithManyParams struct {
-		Param1, Param2, Param3, Param4, Param5  string
-		Param6, Param7, Param8, Param9, Param10 int
-	}
-)
+func b_unused(v any) {}
 
-func _err_unused(v interface{}) {
+func returnNilError() error {
+	return nil
 }
-
-func BenchmarkErr_NewErr_empty(b *testing.B) {
+func BenchmarkError_nil(b *testing.B) {
+	var err error
 	b.StartTimer()
-
 	for i := 0; i < b.N; i++ {
-		err := sabi.NewErr(ReasonForBenchWithNoParam{})
-		_err_unused(err)
+		e := returnNilError()
+		err = e
 	}
-
 	b.StopTimer()
+	b_unused(err)
 }
 
-func BenchmarkErr_NewErr_manyParams(b *testing.B) {
+func returnOkErr() sabi.Err {
+	return sabi.Ok()
+}
+func BenchmarkErr_ok(b *testing.B) {
+	var err sabi.Err
 	b.StartTimer()
-
 	for i := 0; i < b.N; i++ {
-		err := sabi.NewErr(ReasonForBenchWithManyParams{
-			Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-			Param2:  "abcdefghijklmnopqrstuvwxyz",
-			Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
-			Param4:  "f59de3cb-b91c-4c1d-a152-787173d1ab9b",
-			Param5:  "c50c24cd-fe6f-4de7-803e-193d705376b7",
-			Param6:  1234567890,
-			Param7:  9876543210,
-			Param8:  1111111111,
-			Param9:  2222222222,
-			Param10: 3333333333,
-		})
-		_err_unused(err)
+		e := returnOkErr()
+		err = e
 	}
-
 	b.StopTimer()
+	b_unused(err)
 }
 
-func ProcForBenchByVal() sabi.Err {
-	err := sabi.NewErr(ReasonForBenchWithManyParams{
-		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-		Param2:  "abcdefghijklmnopqrstuvwxyz",
-		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
-		Param4:  "f59de3cb-b91c-4c1d-a152-787173d1ab9b",
-		Param5:  "c50c24cd-fe6f-4de7-803e-193d705376b7",
-		Param6:  1234567890,
-		Param7:  9876543210,
-		Param8:  1111111111,
-		Param9:  2222222222,
-		Param10: 3333333333,
-	})
-	return err
-}
-
-func BenchmarkErr_NewErr_byValue(b *testing.B) {
+func BenchmarkError_nil_isNil(b *testing.B) {
+	var err error
+	e := returnNilError()
 	b.StartTimer()
-
 	for i := 0; i < b.N; i++ {
-		err := ProcForBenchByVal()
-		_err_unused(err)
-	}
-
-	b.StopTimer()
-}
-
-func ProcForBenchByPtr() *sabi.Err {
-	err := sabi.NewErr(ReasonForBenchWithManyParams{
-		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-		Param2:  "abcdefghijklmnopqrstuvwxyz",
-		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
-		Param4:  "f59de3cb-b91c-4c1d-a152-787173d1ab9b",
-		Param5:  "c50c24cd-fe6f-4de7-803e-193d705376b7",
-		Param6:  1234567890,
-		Param7:  9876543210,
-		Param8:  1111111111,
-		Param9:  2222222222,
-		Param10: 3333333333,
-	})
-	return &err
-}
-
-func BenchmarkErr_NewErr_byPtr(b *testing.B) {
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		err := ProcForBenchByPtr()
-		_err_unused(err)
-	}
-
-	b.StopTimer()
-}
-
-func BenchmarkErr_Reason_emtpy(b *testing.B) {
-	err := sabi.NewErr(ReasonForBenchWithNoParam{})
-
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		reason := err.Reason()
-		_err_unused(reason)
-	}
-
-	b.StopTimer()
-}
-
-func BenchmarkErr_Reason_manyParams(b *testing.B) {
-	err := sabi.NewErr(ReasonForBenchWithManyParams{
-		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-		Param2:  "abcdefghijklmnopqrstuvwxyz",
-		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
-		Param4:  "f59de3cb-b91c-4c1d-a152-787173d1ab9b",
-		Param5:  "c50c24cd-fe6f-4de7-803e-193d705376b7",
-		Param6:  1234567890,
-		Param7:  9876543210,
-		Param8:  1111111111,
-		Param9:  2222222222,
-		Param10: 3333333333,
-	})
-
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		reason := err.Reason()
-		_err_unused(reason)
-	}
-
-	b.StopTimer()
-}
-
-func BenchmarkErr_Reason_type_emtpy(b *testing.B) {
-	err := sabi.NewErr(ReasonForBenchWithNoParam{})
-
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		switch err.Reason().(type) {
-		case ReasonForBenchWithNoParam, *ReasonForBenchWithNoParam:
+		if e == nil {
+			err = e
 		}
 	}
-
 	b.StopTimer()
+	b_unused(err)
 }
 
-func BenchmarkErr_Reason_type_manyParams(b *testing.B) {
-	err := sabi.NewErr(ReasonForBenchWithManyParams{
-		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-		Param2:  "abcdefghijklmnopqrstuvwxyz",
-		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
-		Param4:  "f59de3cb-b91c-4c1d-a152-787173d1ab9b",
-		Param5:  "c50c24cd-fe6f-4de7-803e-193d705376b7",
-		Param6:  1234567890,
-		Param7:  9876543210,
-		Param8:  1111111111,
-		Param9:  2222222222,
-		Param10: 3333333333,
-	})
-
+func BenchmarkErr_ok_isOk(b *testing.B) {
+	var err sabi.Err
+	e := returnOkErr()
 	b.StartTimer()
-
 	for i := 0; i < b.N; i++ {
-		switch err.Reason().(type) {
-		case ReasonForBenchWithManyParams, *ReasonForBenchWithManyParams:
+		if e.IsOk() {
+			err = e
 		}
 	}
-
 	b.StopTimer()
+	b_unused(err)
 }
 
-func BenchmarkErr_ReasonName(b *testing.B) {
-	err := sabi.NewErr(ReasonForBenchWithManyParams{
-		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-		Param2:  "abcdefghijklmnopqrstuvwxyz",
-		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
-		Param4:  "f59de3cb-b91c-4c1d-a152-787173d1ab9b",
-		Param5:  "c50c24cd-fe6f-4de7-803e-193d705376b7",
-		Param6:  1234567890,
-		Param7:  9876543210,
-		Param8:  1111111111,
-		Param9:  2222222222,
-		Param10: 3333333333,
+func BenchmarkError_nil_typeSwitch(b *testing.B) {
+	var err error
+	e := returnNilError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		switch e.(type) {
+		case nil:
+			err = e
+		default:
+			b.Fail()
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkErr_ok_typeSwitch(b *testing.B) {
+	var err sabi.Err
+	e := returnOkErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		switch e.Reason().(type) {
+		case nil:
+			err = e
+		default:
+			b.Fail()
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkError_nil_ErrorString(b *testing.B) {
+	var str string
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s := "nil"
+		str = s
+	}
+	b.StopTimer()
+	b_unused(str)
+}
+
+func BenchmarkErr_ok_ErrorString(b *testing.B) {
+	var str string
+	e := returnOkErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s := e.Error()
+		str = s
+	}
+	b.StopTimer()
+	b_unused(str)
+}
+
+type EmptyError struct {
+}
+
+func returnEmptyError() error {
+	return EmptyError{}
+}
+func (e EmptyError) Error() string {
+	return "EmptyError"
+}
+func BenchmarkError_empty(b *testing.B) {
+	var err error
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnEmptyError()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+type EmptyReason struct {
+}
+
+func returnEmptyReasonedErr() sabi.Err {
+	return sabi.NewErr(EmptyReason{})
+}
+func BenchmarkErr_emptyReason(b *testing.B) {
+	var err sabi.Err
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnEmptyReasonedErr()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkError_empty_isNotNil(b *testing.B) {
+	var err error
+	e := returnEmptyError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if e != nil {
+			err = e
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkErr_emptyReason_isNotOk(b *testing.B) {
+	var err sabi.Err
+	e := returnEmptyReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if !e.IsOk() {
+			err = e
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkError_empty_typeSwitch(b *testing.B) {
+	var err error
+	e := returnEmptyError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		switch e.(type) {
+		case EmptyError:
+			err = e
+		default:
+			b.Fail()
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkErr_emptyReason_typeSwitch(b *testing.B) {
+	var err sabi.Err
+	e := returnEmptyReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		switch e.Reason().(type) {
+		case EmptyReason:
+			err = e
+		default:
+			b.Fail()
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkError_empty_ErrorString(b *testing.B) {
+	var str string
+	e := returnEmptyError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s := e.Error()
+		str = s
+	}
+	b.StopTimer()
+	b_unused(str)
+}
+
+func BenchmarkErr_emptyReason_ErrorString(b *testing.B) {
+	var str string
+	e := returnEmptyReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s := e.Error()
+		str = s
+	}
+	b.StopTimer()
+	b_unused(str)
+	b_unused(e)
+}
+
+type OneFieldError struct {
+	FieldA string
+}
+
+func (e OneFieldError) Error() string {
+	return "OneFieldError{FieldA:" + e.FieldA + "}"
+}
+func returnOneFieldError() error {
+	return OneFieldError{FieldA: "abc"}
+}
+func BenchmarkError_oneField(b *testing.B) {
+	var err error
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnOneFieldError()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+type OneFieldReason struct {
+	FieldA string
+}
+
+func returnOneFieldReasonedErr() sabi.Err {
+	return sabi.NewErr(OneFieldReason{FieldA: "abc"})
+}
+func BenchmarkErr_oneFieldReason(b *testing.B) {
+	var err sabi.Err
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnOneFieldReasonedErr()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func returnOneFieldErrorPtr() error {
+	return &OneFieldError{FieldA: "abc"}
+}
+func BenchmarkError_oneFieldPtr(b *testing.B) {
+	var err error
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnOneFieldErrorPtr()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func returnOneFieldReasonedPtrErr() sabi.Err {
+	return sabi.NewErr(&OneFieldReason{FieldA: "abc"})
+}
+func BenchmarkErr_oneFieldReasonPtr(b *testing.B) {
+	var err sabi.Err
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnOneFieldReasonedPtrErr()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkError_oneField_isNotNil(b *testing.B) {
+	var err error
+	e := returnOneFieldError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if e != nil {
+			err = e
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkErr_oneFieldReason_isNotOk(b *testing.B) {
+	var err sabi.Err
+	e := returnOneFieldReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if !e.IsOk() {
+			err = e
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkError_oneField_typeSwitch(b *testing.B) {
+	var err error
+	e := returnOneFieldError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		switch e.(type) {
+		case OneFieldError:
+			err = e
+		default:
+			b.Fail()
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkErr_oneFieldReason_typeSwitch(b *testing.B) {
+	var err sabi.Err
+	e := returnOneFieldReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		switch e.Reason().(type) {
+		case OneFieldReason:
+			err = e
+		default:
+			b.Fail()
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkError_oneField_ErrorString(b *testing.B) {
+	var str string
+	e := returnOneFieldError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s := e.Error()
+		str = s
+	}
+	b.StopTimer()
+	b_unused(str)
+}
+
+func BenchmarkErr_oneFieldReason_ErrorString(b *testing.B) {
+	var str string
+	e := returnOneFieldReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s := e.Error()
+		str = s
+	}
+	b.StopTimer()
+	b_unused(str)
+}
+
+type FiveFieldError struct {
+	FieldA string
+	FieldB int
+	FieldC bool
+	FieldD string
+	FieldE string
+}
+
+func (e FiveFieldError) Error() string {
+	return "FiveFieldError{FieldA:" + e.FieldA +
+		",FieldB:" + strconv.Itoa(e.FieldB) +
+		",FieldC:" + strconv.FormatBool(e.FieldC) +
+		",FieldD:" + e.FieldD + ",FieldE:" + e.FieldE +
+		"}"
+}
+func returnFiveFieldError() error {
+	return FiveFieldError{
+		FieldA: "abc", FieldB: 123, FieldC: true, FieldD: "def", FieldE: "ghi",
+	}
+}
+func BenchmarkError_fiveField(b *testing.B) {
+	var err error
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnFiveFieldError()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+type FiveFieldReason struct {
+	FieldA string
+	FieldB int
+	FieldC bool
+	FieldD string
+	FieldE string
+}
+
+func returnFiveFieldReasonedErr() sabi.Err {
+	return sabi.NewErr(FiveFieldReason{
+		FieldA: "abc", FieldB: 123, FieldC: true, FieldD: "def", FieldE: "ghi",
 	})
-
+}
+func BenchmarkErr_fiveFieldReason(b *testing.B) {
+	var err sabi.Err
 	b.StartTimer()
-
 	for i := 0; i < b.N; i++ {
-		name := err.ReasonName()
-		_err_unused(name)
+		e := returnFiveFieldReasonedErr()
+		err = e
 	}
-
 	b.StopTimer()
+	b_unused(err)
 }
 
-func BenchmarkErr_Cause(b *testing.B) {
-	cause := errors.New("Causal error")
-	err := sabi.NewErr(ReasonForBenchWithManyParams{
-		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-		Param2:  "abcdefghijklmnopqrstuvwxyz",
-		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
-		Param4:  "f59de3cb-b91c-4c1d-a152-787173d1ab9b",
-		Param5:  "c50c24cd-fe6f-4de7-803e-193d705376b7",
-		Param6:  1234567890,
-		Param7:  9876543210,
-		Param8:  1111111111,
-		Param9:  2222222222,
-		Param10: 3333333333,
-	}, cause)
-
+func BenchmarkError_fiveField_isNotNil(b *testing.B) {
+	var err error
+	e := returnFiveFieldError()
 	b.StartTimer()
-
 	for i := 0; i < b.N; i++ {
-		cause := err.Cause()
-		_err_unused(cause)
+		if e != nil {
+			err = e
+		}
 	}
-
 	b.StopTimer()
+	b_unused(err)
 }
 
-func BenchmarkErr_Situation(b *testing.B) {
-	err := sabi.NewErr(ReasonForBenchWithManyParams{
-		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-		Param2:  "abcdefghijklmnopqrstuvwxyz",
-		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
-		Param4:  "f59de3cb-b91c-4c1d-a152-787173d1ab9b",
-		Param5:  "c50c24cd-fe6f-4de7-803e-193d705376b7",
-		Param6:  1234567890,
-		Param7:  9876543210,
-		Param8:  1111111111,
-		Param9:  2222222222,
-		Param10: 3333333333,
-	})
-
+func BenchmarkErr_fiveFieldReason_isNotOk(b *testing.B) {
+	var err sabi.Err
+	e := returnFiveFieldReasonedErr()
 	b.StartTimer()
-
 	for i := 0; i < b.N; i++ {
-		m := err.Situation()
-		_err_unused(m)
+		if !e.IsOk() {
+			err = e
+		}
 	}
-
 	b.StopTimer()
+	b_unused(err)
 }
 
-func BenchmarkErr_Get(b *testing.B) {
-	err := sabi.NewErr(ReasonForBenchWithManyParams{
-		Param1:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-		Param2:  "abcdefghijklmnopqrstuvwxyz",
-		Param3:  "8b91114c-f620-46bc-a991-25c7ac0f7935",
-		Param4:  "f59de3cb-b91c-4c1d-a152-787173d1ab9b",
-		Param5:  "c50c24cd-fe6f-4de7-803e-193d705376b7",
-		Param6:  1234567890,
-		Param7:  9876543210,
-		Param8:  1111111111,
-		Param9:  2222222222,
-		Param10: 3333333333,
-	})
-
+func BenchmarkError_fiveField_typeSwitch(b *testing.B) {
+	var err error
+	e := returnFiveFieldError()
 	b.StartTimer()
-
 	for i := 0; i < b.N; i++ {
-		s1 := err.Get("Param1").(string)
-		s2 := err.Get("Param2").(string)
-		s3 := err.Get("Param3").(string)
-		s4 := err.Get("Param4").(string)
-		s5 := err.Get("Param5").(string)
-		n1 := err.Get("Param6").(int)
-		n2 := err.Get("Param7").(int)
-		n3 := err.Get("Param8").(int)
-		n4 := err.Get("Param9").(int)
-		n5 := err.Get("Param10").(int)
-		_err_unused(s1)
-		_err_unused(s2)
-		_err_unused(s3)
-		_err_unused(s4)
-		_err_unused(s5)
-		_err_unused(n1)
-		_err_unused(n2)
-		_err_unused(n3)
-		_err_unused(n4)
-		_err_unused(n5)
+		switch e.(type) {
+		case FiveFieldError:
+			err = e
+		default:
+			b.Fail()
+		}
 	}
-
 	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkErr_fiveFieldReason_typeSwitch(b *testing.B) {
+	var err sabi.Err
+	e := returnFiveFieldReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		switch e.Reason().(type) {
+		case FiveFieldReason:
+			err = e
+		default:
+			b.Fail()
+		}
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkError_fiveField_ErrorString(b *testing.B) {
+	var str string
+	e := returnFiveFieldError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s := e.Error()
+		str = s
+	}
+	b.StopTimer()
+	b_unused(str)
+}
+
+func BenchmarkErr_fiveFieldReason_ErrorString(b *testing.B) {
+	var str string
+	e := returnFiveFieldReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s := e.Error()
+		str = s
+	}
+	b.StopTimer()
+	b_unused(str)
+}
+
+type HavingCauseError struct {
+	Cause error
+}
+
+func (e HavingCauseError) Error() string {
+	return "HavingCauseError{cause:" + e.Cause.Error() + "}"
+}
+func (e HavingCauseError) Unwrap() error {
+	return e.Cause
+}
+func returnHavingCauseError() error {
+	return HavingCauseError{Cause: EmptyError{}}
+}
+func BenchmarkError_havingCause(b *testing.B) {
+	var err error
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnHavingCauseError()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+type HavingCauseReason struct {
+}
+
+func returnHavingCauseReasonedErr() sabi.Err {
+	return sabi.NewErr(HavingCauseError{}, EmptyError{})
+}
+func BenchmarkErr_havingCauseReason(b *testing.B) {
+	var err sabi.Err
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnHavingCauseReasonedErr()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkError_havingCause_ErrorString(b *testing.B) {
+	var str string
+	e := returnHavingCauseError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s := e.Error()
+		str = s
+	}
+	b.StopTimer()
+	b_unused(str)
+}
+
+func BenchmarkErr_havingCauseReason_ErrorString(b *testing.B) {
+	var str string
+	e := returnHavingCauseReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s := e.Error()
+		str = s
+	}
+	b.StopTimer()
+	b_unused(str)
 }

--- a/benchmark_notify_test.go
+++ b/benchmark_notify_test.go
@@ -1,0 +1,69 @@
+package sabi_test
+
+import (
+	"github.com/sttk-go/sabi"
+	"testing"
+)
+
+func BenchmarkNotify_addErrHandler(b *testing.B) {
+	b.StartTimer()
+	//sabi.AddSyncErrHandler(func(err sabi.Err, occ sabi.ErrOccasion) {})
+	sabi.AddAsyncErrHandler(func(err sabi.Err, occ sabi.ErrOccasion) {})
+	sabi.FixErrCfgs()
+	b.StopTimer()
+}
+
+func BenchmarkNotify_ok(b *testing.B) {
+	var err sabi.Err
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnOkErr()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkNotify_emptyReason(b *testing.B) {
+	var err sabi.Err
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnEmptyReasonedErr()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkNotify_oneFieldReason(b *testing.B) {
+	var err sabi.Err
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnOneFieldReasonedErr()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkNotify_fiveFieldReason(b *testing.B) {
+	var err sabi.Err
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnFiveFieldReasonedErr()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}
+
+func BenchmarkNotify_havingCauseReason(b *testing.B) {
+	var err sabi.Err
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		e := returnHavingCauseReasonedErr()
+		err = e
+	}
+	b.StopTimer()
+	b_unused(err)
+}

--- a/err_test.go
+++ b/err_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-type /* error reason */ (
+type /* error reasons */ (
 	InvalidValue struct {
 		Value string
 	}

--- a/err_test.go
+++ b/err_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-type /* error reasons */ (
+type /* error reason */ (
 	InvalidValue struct {
 		Value string
 	}
@@ -16,12 +16,18 @@ type /* error reasons */ (
 	}
 )
 
+type InvalidValueError struct {
+	Value string
+}
+
+func (e InvalidValueError) Error() string {
+	return "InvalidValue{Value=" + e.Value + "}"
+}
+
 func TestNewErr_reasonIsValue(t *testing.T) {
 	err := sabi.NewErr(InvalidValue{Value: "abc"})
 
 	assert.Equal(t, err.Error(), "{reason=InvalidValue, Value=abc}")
-	assert.Equal(t, err.FileName(), "err_test.go")
-	assert.Equal(t, err.LineNumber(), 20)
 
 	switch err.Reason().(type) {
 	case InvalidValue:
@@ -43,14 +49,20 @@ func TestNewErr_reasonIsValue(t *testing.T) {
 
 	assert.Nil(t, err.Cause())
 	assert.Nil(t, err.Unwrap())
+	assert.Nil(t, errors.Unwrap(err))
+
+	assert.True(t, errors.Is(err, err))
+	assert.True(t, errors.As(err, &err))
+
+	e := InvalidValueError{Value: "aaa"}
+	assert.False(t, errors.Is(err, e))
+	assert.False(t, errors.As(err, &e))
 }
 
 func TestNewErr_reasonIsPointer(t *testing.T) {
 	err := sabi.NewErr(&InvalidValue{Value: "abc"})
 
 	assert.Equal(t, err.Error(), "{reason=InvalidValue, Value=abc}")
-	assert.Equal(t, err.FileName(), "err_test.go")
-	assert.Equal(t, err.LineNumber(), 49)
 
 	switch err.Reason().(type) {
 	case *InvalidValue:
@@ -72,6 +84,14 @@ func TestNewErr_reasonIsPointer(t *testing.T) {
 
 	assert.Nil(t, err.Cause())
 	assert.Nil(t, err.Unwrap())
+	assert.Nil(t, errors.Unwrap(err))
+
+	assert.True(t, errors.Is(err, err))
+	assert.True(t, errors.As(err, &err))
+
+	e := InvalidValueError{Value: "aaa"}
+	assert.False(t, errors.Is(err, e))
+	assert.False(t, errors.As(err, &e))
 }
 
 func TestNewErr_withCause(t *testing.T) {
@@ -79,8 +99,6 @@ func TestNewErr_withCause(t *testing.T) {
 	err := sabi.NewErr(InvalidValue{Value: "abc"}, cause)
 
 	assert.Equal(t, err.Error(), "{reason=InvalidValue, Value=abc, cause=def}")
-	assert.Equal(t, err.FileName(), "err_test.go")
-	assert.Equal(t, err.LineNumber(), 79)
 
 	switch err.Reason().(type) {
 	case InvalidValue:
@@ -102,6 +120,16 @@ func TestNewErr_withCause(t *testing.T) {
 	assert.Equal(t, err.Cause(), cause)
 	assert.Equal(t, err.Unwrap(), cause)
 	assert.Equal(t, errors.Unwrap(err), cause)
+
+	assert.True(t, errors.Is(err, err))
+	assert.True(t, errors.As(err, &err))
+
+	assert.True(t, errors.Is(err, cause))
+	//assert.True(t, errors.As(err, cause)) --> compile error
+
+	e := InvalidValueError{Value: "aaa"}
+	assert.False(t, errors.Is(err, e))
+	assert.False(t, errors.As(err, &e))
 }
 
 func TestNewErr_causeIsAlsoErr(t *testing.T) {
@@ -109,8 +137,6 @@ func TestNewErr_causeIsAlsoErr(t *testing.T) {
 	err := sabi.NewErr(InvalidValue{Value: "abc"}, cause)
 
 	assert.Equal(t, err.Error(), "{reason=InvalidValue, Value=abc, cause={reason=FailToGetValue, Name=foo}}")
-	assert.Equal(t, err.FileName(), "err_test.go")
-	assert.Equal(t, err.LineNumber(), 109)
 
 	switch err.Reason().(type) {
 	case InvalidValue:
@@ -134,24 +160,33 @@ func TestNewErr_causeIsAlsoErr(t *testing.T) {
 	assert.Equal(t, err.Cause(), cause)
 	assert.Equal(t, err.Unwrap(), cause)
 	assert.Equal(t, errors.Unwrap(err), cause)
+
+	assert.True(t, errors.Is(err, err))
+	assert.True(t, errors.As(err, &err))
+
+	assert.True(t, errors.Is(err, cause))
+	assert.True(t, errors.As(err, &cause))
+
+	e := InvalidValueError{Value: "aaa"}
+	assert.False(t, errors.Is(err, e))
+	assert.False(t, errors.As(err, &e))
 }
 
 func TestOk(t *testing.T) {
 	err := sabi.Ok()
 
-	assert.Equal(t, err.Error(), "{reason=NoError}")
-	assert.Equal(t, err.FileName(), "")
-	assert.Equal(t, err.LineNumber(), 0)
+	assert.Equal(t, err.Error(), "{reason=nil}")
+	assert.Nil(t, err.Reason())
 
 	switch err.Reason().(type) {
-	case sabi.NoError:
+	case nil:
 	default:
 		assert.Fail(t, err.Error())
 	}
 
 	assert.True(t, err.IsOk())
-	assert.Equal(t, err.ReasonName(), "NoError")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi")
+	assert.Equal(t, err.ReasonName(), "")
+	assert.Equal(t, err.ReasonPackage(), "")
 	assert.Nil(t, err.Get("Value"))
 	assert.Nil(t, err.Get("value"))
 	assert.Nil(t, err.Get("Name"))
@@ -161,4 +196,12 @@ func TestOk(t *testing.T) {
 
 	assert.Nil(t, err.Cause())
 	assert.Nil(t, err.Unwrap())
+	assert.Nil(t, errors.Unwrap(err))
+
+	assert.True(t, errors.Is(err, err))
+	assert.True(t, errors.As(err, &err))
+
+	e := InvalidValueError{Value: "aaa"}
+	assert.False(t, errors.Is(err, e))
+	assert.False(t, errors.As(err, &e))
 }

--- a/example_err_test.go
+++ b/example_err_test.go
@@ -52,7 +52,7 @@ func ExampleOk() {
 	fmt.Printf("err.IsOk() = %v\n", err.IsOk())
 
 	// Output:
-	// err = {reason=NoError}
+	// err = {reason=nil}
 	// err.IsOk() = true
 }
 
@@ -86,16 +86,6 @@ func ExampleErr_Error() {
 	// {reason=FailToDoSomething, Param1=ABC, Param2=123, cause=Causal error}
 }
 
-func ExampleErr_FileName() {
-	type FailToDoSomething struct{}
-
-	err := sabi.NewErr(FailToDoSomething{})
-	fmt.Printf("%v\n", err.FileName())
-
-	// Output:
-	// example_err_test.go
-}
-
 func ExampleErr_Get() {
 	type FailToDoSomething struct {
 		Param1 string
@@ -127,16 +117,6 @@ func ExampleErr_IsOk() {
 	// Output:
 	// true
 	// false
-}
-
-func ExampleErr_LineNumber() {
-	type FailToDoSomething struct{}
-
-	err := sabi.NewErr(FailToDoSomething{})
-	fmt.Printf("%v\n", err.LineNumber())
-
-	// Output:
-	// 135
 }
 
 func ExampleErr_Reason() {
@@ -212,11 +192,17 @@ func ExampleErr_Unwrap() {
 	err := sabi.NewErr(FailToDoSomething{}, cause1)
 
 	fmt.Printf("err.Unwrap() = %v\n", err.Unwrap())
+	fmt.Printf("errors.Unwrap(err) = %v\n", errors.Unwrap(err))
 	fmt.Printf("errors.Is(err, cause1) = %v\n", errors.Is(err, cause1))
 	fmt.Printf("errors.Is(err, cause2) = %v\n", errors.Is(err, cause2))
+	fmt.Printf("errors.As(err, cause1) = %v\n", errors.Is(err, cause1))
+	fmt.Printf("errors.As(err, cause2) = %v\n", errors.Is(err, cause2))
 
 	// Output:
 	// err.Unwrap() = Causal error 1
+	// errors.Unwrap(err) = Causal error 1
 	// errors.Is(err, cause1) = true
 	// errors.Is(err, cause2) = false
+	// errors.As(err, cause1) = true
+	// errors.As(err, cause2) = false
 }

--- a/example_err_test.go
+++ b/example_err_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ExampleNewErr() {
-	type /* error reason */ (
+	type /* error reasons */ (
 		FailToDoSomething           struct{}
 		FailToDoSomethingWithParams struct {
 			Param1 string

--- a/example_notify_test.go
+++ b/example_notify_test.go
@@ -3,11 +3,12 @@ package sabi_test
 import (
 	"fmt"
 	"github.com/sttk-go/sabi"
+	"strconv"
 	"time"
 )
 
 func ExampleAddAsyncErrHandler() {
-	sabi.AddAsyncErrHandler(func(err sabi.Err, tm time.Time) {
+	sabi.AddAsyncErrHandler(func(err sabi.Err, occ sabi.ErrOccasion) {
 		fmt.Println("Asynchronous error handling: " + err.Error())
 	})
 	sabi.FixErrCfgs()
@@ -24,7 +25,7 @@ func ExampleAddAsyncErrHandler() {
 }
 
 func ExampleAddSyncErrHandler() {
-	sabi.AddSyncErrHandler(func(err sabi.Err, tm time.Time) {
+	sabi.AddSyncErrHandler(func(err sabi.Err, occ sabi.ErrOccasion) {
 		fmt.Println("Synchronous error handling: " + err.Error())
 	})
 	sabi.FixErrCfgs()
@@ -40,13 +41,14 @@ func ExampleAddSyncErrHandler() {
 }
 
 func ExampleFixErrCfgs() {
-	sabi.AddSyncErrHandler(func(err sabi.Err, tm time.Time) {
-		fmt.Println("This handler is registered")
+	sabi.AddSyncErrHandler(func(err sabi.Err, occ sabi.ErrOccasion) {
+		fmt.Println("This handler is registered at " + occ.File() + ":" +
+			strconv.Itoa(occ.Line()))
 	})
 
 	sabi.FixErrCfgs()
 
-	sabi.AddSyncErrHandler(func(err sabi.Err, tm time.Time) { // Bad example
+	sabi.AddSyncErrHandler(func(err sabi.Err, occ sabi.ErrOccasion) {
 		fmt.Println("This handler is not registered")
 	})
 
@@ -55,7 +57,7 @@ func ExampleFixErrCfgs() {
 	sabi.NewErr(FailToDoSomething{Name: "abc"})
 
 	// Output:
-	// This handler is registered
+	// This handler is registered at example_notify_test.go:57
 
 	sabi.ClearErrHandlers()
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sttk-go/sabi
 
 go 1.18
 
-require github.com/stretchr/testify v1.8.0
+require github.com/stretchr/testify v1.8.2
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,9 +5,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/notify_test.go
+++ b/notify_test.go
@@ -4,6 +4,7 @@ import (
 	"container/list"
 	"github.com/stretchr/testify/assert"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -22,7 +23,7 @@ func TestAddErrSyncHandler_oneHandler(t *testing.T) {
 	ClearErrHandlers()
 	defer ClearErrHandlers()
 
-	AddSyncErrHandler(func(err Err, tm time.Time) {})
+	AddSyncErrHandler(func(err Err, occ ErrOccasion) {})
 
 	assert.NotNil(t, syncErrHandlers.head)
 	assert.NotNil(t, syncErrHandlers.last)
@@ -32,15 +33,15 @@ func TestAddErrSyncHandler_oneHandler(t *testing.T) {
 	assert.Nil(t, syncErrHandlers.head.next)
 
 	assert.NotNil(t, syncErrHandlers.head.handler)
-	assert.Equal(t, reflect.TypeOf(syncErrHandlers.head.handler).String(), "func(sabi.Err, time.Time)")
+	assert.Equal(t, reflect.TypeOf(syncErrHandlers.head.handler).String(), "func(sabi.Err, sabi.ErrOccasion)")
 }
 
 func TestAddErrSyncHandler_twoHandlers(t *testing.T) {
 	ClearErrHandlers()
 	defer ClearErrHandlers()
 
-	AddSyncErrHandler(func(err Err, tm time.Time) {})
-	AddSyncErrHandler(func(err Err, tm time.Time) {})
+	AddSyncErrHandler(func(err Err, occ ErrOccasion) {})
+	AddSyncErrHandler(func(err Err, occ ErrOccasion) {})
 
 	assert.NotNil(t, syncErrHandlers.head)
 	assert.NotNil(t, syncErrHandlers.last)
@@ -50,10 +51,10 @@ func TestAddErrSyncHandler_twoHandlers(t *testing.T) {
 	assert.Nil(t, syncErrHandlers.last.next)
 
 	assert.NotNil(t, syncErrHandlers.head.handler)
-	assert.Equal(t, reflect.TypeOf(syncErrHandlers.head.handler).String(), "func(sabi.Err, time.Time)")
+	assert.Equal(t, reflect.TypeOf(syncErrHandlers.head.handler).String(), "func(sabi.Err, sabi.ErrOccasion)")
 
 	assert.NotNil(t, syncErrHandlers.head.next.handler)
-	assert.Equal(t, reflect.TypeOf(syncErrHandlers.head.next.handler).String(), "func(sabi.Err, time.Time)")
+	assert.Equal(t, reflect.TypeOf(syncErrHandlers.head.next.handler).String(), "func(sabi.Err, sabi.ErrOccasion)")
 }
 
 func TestAddErrAsyncHandler_zeroHandler(t *testing.T) {
@@ -68,7 +69,7 @@ func TestAddErrAsyncHandler_oneHandler(t *testing.T) {
 	ClearErrHandlers()
 	defer ClearErrHandlers()
 
-	AddAsyncErrHandler(func(err Err, tm time.Time) {})
+	AddAsyncErrHandler(func(err Err, occ ErrOccasion) {})
 
 	assert.NotNil(t, asyncErrHandlers.head)
 	assert.NotNil(t, asyncErrHandlers.last)
@@ -78,15 +79,15 @@ func TestAddErrAsyncHandler_oneHandler(t *testing.T) {
 	assert.Nil(t, asyncErrHandlers.head.next)
 
 	assert.NotNil(t, asyncErrHandlers.head.handler)
-	assert.Equal(t, reflect.TypeOf(asyncErrHandlers.head.handler).String(), "func(sabi.Err, time.Time)")
+	assert.Equal(t, reflect.TypeOf(asyncErrHandlers.head.handler).String(), "func(sabi.Err, sabi.ErrOccasion)")
 }
 
 func TestAddErrAsyncHandler_twoHandlers(t *testing.T) {
 	ClearErrHandlers()
 	defer ClearErrHandlers()
 
-	AddAsyncErrHandler(func(err Err, tm time.Time) {})
-	AddAsyncErrHandler(func(err Err, tm time.Time) {})
+	AddAsyncErrHandler(func(err Err, occ ErrOccasion) {})
+	AddAsyncErrHandler(func(err Err, occ ErrOccasion) {})
 
 	assert.NotNil(t, asyncErrHandlers.head)
 	assert.NotNil(t, asyncErrHandlers.last)
@@ -96,18 +97,18 @@ func TestAddErrAsyncHandler_twoHandlers(t *testing.T) {
 	assert.Nil(t, asyncErrHandlers.last.next)
 
 	assert.NotNil(t, asyncErrHandlers.head.handler)
-	assert.Equal(t, reflect.TypeOf(asyncErrHandlers.head.handler).String(), "func(sabi.Err, time.Time)")
+	assert.Equal(t, reflect.TypeOf(asyncErrHandlers.head.handler).String(), "func(sabi.Err, sabi.ErrOccasion)")
 
 	assert.NotNil(t, asyncErrHandlers.head.next.handler)
-	assert.Equal(t, reflect.TypeOf(asyncErrHandlers.head.next.handler).String(), "func(sabi.Err, time.Time)")
+	assert.Equal(t, reflect.TypeOf(asyncErrHandlers.head.next.handler).String(), "func(sabi.Err, sabi.ErrOccasion)")
 }
 
 func TestFixErrCfgs(t *testing.T) {
 	ClearErrHandlers()
 	defer ClearErrHandlers()
 
-	AddSyncErrHandler(func(err Err, tm time.Time) {})
-	AddAsyncErrHandler(func(err Err, tm time.Time) {})
+	AddSyncErrHandler(func(err Err, occ ErrOccasion) {})
+	AddAsyncErrHandler(func(err Err, occ ErrOccasion) {})
 
 	assert.NotNil(t, syncErrHandlers.head)
 	assert.NotNil(t, syncErrHandlers.last)
@@ -129,8 +130,8 @@ func TestFixErrCfgs(t *testing.T) {
 
 	assert.True(t, isErrCfgsFixed)
 
-	AddSyncErrHandler(func(err Err, tm time.Time) {})
-	AddAsyncErrHandler(func(err Err, tm time.Time) {})
+	AddSyncErrHandler(func(err Err, occ ErrOccasion) {})
+	AddAsyncErrHandler(func(err Err, occ ErrOccasion) {})
 
 	assert.NotNil(t, syncErrHandlers.head)
 	assert.NotNil(t, syncErrHandlers.last)
@@ -169,14 +170,17 @@ func TestNotifyErr_withHandlers(t *testing.T) {
 	syncLogs := list.New()
 	asyncLogs := list.New()
 
-	AddSyncErrHandler(func(err Err, tm time.Time) {
-		syncLogs.PushBack(err.ReasonName() + "-1")
+	AddSyncErrHandler(func(err Err, occ ErrOccasion) {
+		syncLogs.PushBack(
+			err.ReasonName() + "-1:" + occ.File() + ":" + strconv.Itoa(occ.Line()))
 	})
-	AddSyncErrHandler(func(err Err, tm time.Time) {
-		syncLogs.PushBack(err.ReasonName() + "-2")
+	AddSyncErrHandler(func(err Err, occ ErrOccasion) {
+		syncLogs.PushBack(
+			err.ReasonName() + "-2:" + occ.File() + ":" + strconv.Itoa(occ.Line()))
 	})
-	AddAsyncErrHandler(func(err Err, tm time.Time) {
-		asyncLogs.PushBack(err.ReasonName() + "-3")
+	AddAsyncErrHandler(func(err Err, occ ErrOccasion) {
+		asyncLogs.PushBack(
+			err.ReasonName() + "-3:" + occ.File() + ":" + strconv.Itoa(occ.Line()))
 	})
 
 	NewErr(ReasonForNotification{})
@@ -193,11 +197,14 @@ func TestNotifyErr_withHandlers(t *testing.T) {
 	assert.True(t, isErrCfgsFixed)
 
 	assert.Equal(t, syncLogs.Len(), 2)
-	assert.Equal(t, syncLogs.Front().Value, "ReasonForNotification-1")
-	assert.Equal(t, syncLogs.Front().Next().Value, "ReasonForNotification-2")
+	assert.Equal(t, syncLogs.Front().Value,
+		"ReasonForNotification-1:notify_test.go:195")
+	assert.Equal(t, syncLogs.Front().Next().Value,
+		"ReasonForNotification-2:notify_test.go:195")
 
 	time.Sleep(100 * time.Millisecond)
 
 	assert.Equal(t, asyncLogs.Len(), 1)
-	assert.Equal(t, asyncLogs.Front().Value, "ReasonForNotification-3")
+	assert.Equal(t, asyncLogs.Front().Value,
+		"ReasonForNotification-3:notify_test.go:195")
 }


### PR DESCRIPTION
It is the cause of slow that `Err` struct has four fields and calls `runtime.Caller` function to get a file name and a line number to set two of their fields.

So this PR removes the two fields from `Err` struct and make a file name and a line number passed to error creation handlers as arguments.