### PR TITLE
test: rewrote test codes

### DIFF
--- a/benchmark_err_test.go
+++ b/benchmark_err_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func b_unused(v any) {}
+func unused(v any) {}
 
 func returnNilError() error {
 	return nil
@@ -19,7 +19,7 @@ func BenchmarkError_nil(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func returnOkErr() sabi.Err {
@@ -33,7 +33,7 @@ func BenchmarkErr_ok(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_nil_isNil(b *testing.B) {
@@ -46,7 +46,7 @@ func BenchmarkError_nil_isNil(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkErr_ok_isOk(b *testing.B) {
@@ -59,7 +59,7 @@ func BenchmarkErr_ok_isOk(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_nil_typeSwitch(b *testing.B) {
@@ -75,7 +75,7 @@ func BenchmarkError_nil_typeSwitch(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkErr_ok_typeSwitch(b *testing.B) {
@@ -91,7 +91,7 @@ func BenchmarkErr_ok_typeSwitch(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_nil_ErrorString(b *testing.B) {
@@ -102,7 +102,7 @@ func BenchmarkError_nil_ErrorString(b *testing.B) {
 		str = s
 	}
 	b.StopTimer()
-	b_unused(str)
+	unused(str)
 }
 
 func BenchmarkErr_ok_ErrorString(b *testing.B) {
@@ -114,7 +114,7 @@ func BenchmarkErr_ok_ErrorString(b *testing.B) {
 		str = s
 	}
 	b.StopTimer()
-	b_unused(str)
+	unused(str)
 }
 
 type EmptyError struct {
@@ -134,7 +134,7 @@ func BenchmarkError_empty(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 type EmptyReason struct {
@@ -151,7 +151,7 @@ func BenchmarkErr_emptyReason(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_empty_isNotNil(b *testing.B) {
@@ -164,7 +164,7 @@ func BenchmarkError_empty_isNotNil(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkErr_emptyReason_isNotOk(b *testing.B) {
@@ -177,7 +177,7 @@ func BenchmarkErr_emptyReason_isNotOk(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_empty_typeSwitch(b *testing.B) {
@@ -193,7 +193,7 @@ func BenchmarkError_empty_typeSwitch(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkErr_emptyReason_typeSwitch(b *testing.B) {
@@ -209,7 +209,7 @@ func BenchmarkErr_emptyReason_typeSwitch(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_empty_ErrorString(b *testing.B) {
@@ -221,7 +221,7 @@ func BenchmarkError_empty_ErrorString(b *testing.B) {
 		str = s
 	}
 	b.StopTimer()
-	b_unused(str)
+	unused(str)
 }
 
 func BenchmarkErr_emptyReason_ErrorString(b *testing.B) {
@@ -233,8 +233,8 @@ func BenchmarkErr_emptyReason_ErrorString(b *testing.B) {
 		str = s
 	}
 	b.StopTimer()
-	b_unused(str)
-	b_unused(e)
+	unused(str)
+	unused(e)
 }
 
 type OneFieldError struct {
@@ -255,7 +255,7 @@ func BenchmarkError_oneField(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 type OneFieldReason struct {
@@ -273,7 +273,7 @@ func BenchmarkErr_oneFieldReason(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func returnOneFieldErrorPtr() error {
@@ -287,7 +287,7 @@ func BenchmarkError_oneFieldPtr(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func returnOneFieldReasonedPtrErr() sabi.Err {
@@ -301,7 +301,7 @@ func BenchmarkErr_oneFieldReasonPtr(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_oneField_isNotNil(b *testing.B) {
@@ -314,7 +314,7 @@ func BenchmarkError_oneField_isNotNil(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkErr_oneFieldReason_isNotOk(b *testing.B) {
@@ -327,7 +327,7 @@ func BenchmarkErr_oneFieldReason_isNotOk(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_oneField_typeSwitch(b *testing.B) {
@@ -343,7 +343,7 @@ func BenchmarkError_oneField_typeSwitch(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkErr_oneFieldReason_typeSwitch(b *testing.B) {
@@ -359,7 +359,7 @@ func BenchmarkErr_oneFieldReason_typeSwitch(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_oneField_ErrorString(b *testing.B) {
@@ -371,7 +371,7 @@ func BenchmarkError_oneField_ErrorString(b *testing.B) {
 		str = s
 	}
 	b.StopTimer()
-	b_unused(str)
+	unused(str)
 }
 
 func BenchmarkErr_oneFieldReason_ErrorString(b *testing.B) {
@@ -383,7 +383,7 @@ func BenchmarkErr_oneFieldReason_ErrorString(b *testing.B) {
 		str = s
 	}
 	b.StopTimer()
-	b_unused(str)
+	unused(str)
 }
 
 type FiveFieldError struct {
@@ -414,7 +414,7 @@ func BenchmarkError_fiveField(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 type FiveFieldReason struct {
@@ -438,7 +438,7 @@ func BenchmarkErr_fiveFieldReason(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_fiveField_isNotNil(b *testing.B) {
@@ -451,7 +451,7 @@ func BenchmarkError_fiveField_isNotNil(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkErr_fiveFieldReason_isNotOk(b *testing.B) {
@@ -464,7 +464,7 @@ func BenchmarkErr_fiveFieldReason_isNotOk(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_fiveField_typeSwitch(b *testing.B) {
@@ -480,7 +480,7 @@ func BenchmarkError_fiveField_typeSwitch(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkErr_fiveFieldReason_typeSwitch(b *testing.B) {
@@ -496,7 +496,7 @@ func BenchmarkErr_fiveFieldReason_typeSwitch(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_fiveField_ErrorString(b *testing.B) {
@@ -508,7 +508,7 @@ func BenchmarkError_fiveField_ErrorString(b *testing.B) {
 		str = s
 	}
 	b.StopTimer()
-	b_unused(str)
+	unused(str)
 }
 
 func BenchmarkErr_fiveFieldReason_ErrorString(b *testing.B) {
@@ -520,7 +520,7 @@ func BenchmarkErr_fiveFieldReason_ErrorString(b *testing.B) {
 		str = s
 	}
 	b.StopTimer()
-	b_unused(str)
+	unused(str)
 }
 
 type HavingCauseError struct {
@@ -544,7 +544,7 @@ func BenchmarkError_havingCause(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 type HavingCauseReason struct {
@@ -561,7 +561,7 @@ func BenchmarkErr_havingCauseReason(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused(err)
 }
 
 func BenchmarkError_havingCause_ErrorString(b *testing.B) {
@@ -573,7 +573,7 @@ func BenchmarkError_havingCause_ErrorString(b *testing.B) {
 		str = s
 	}
 	b.StopTimer()
-	b_unused(str)
+	unused(str)
 }
 
 func BenchmarkErr_havingCauseReason_ErrorString(b *testing.B) {
@@ -585,5 +585,5 @@ func BenchmarkErr_havingCauseReason_ErrorString(b *testing.B) {
 		str = s
 	}
 	b.StopTimer()
-	b_unused(str)
+	unused(str)
 }

--- a/benchmark_notify_test.go
+++ b/benchmark_notify_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+func unused2(v any) {}
+
 func BenchmarkNotify_addErrHandler(b *testing.B) {
 	b.StartTimer()
 	//sabi.AddSyncErrHandler(func(err sabi.Err, occ sabi.ErrOccasion) {})
@@ -21,7 +23,7 @@ func BenchmarkNotify_ok(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused2(err)
 }
 
 func BenchmarkNotify_emptyReason(b *testing.B) {
@@ -32,7 +34,7 @@ func BenchmarkNotify_emptyReason(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused2(err)
 }
 
 func BenchmarkNotify_oneFieldReason(b *testing.B) {
@@ -43,7 +45,7 @@ func BenchmarkNotify_oneFieldReason(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused2(err)
 }
 
 func BenchmarkNotify_fiveFieldReason(b *testing.B) {
@@ -54,7 +56,7 @@ func BenchmarkNotify_fiveFieldReason(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused2(err)
 }
 
 func BenchmarkNotify_havingCauseReason(b *testing.B) {
@@ -65,5 +67,5 @@ func BenchmarkNotify_havingCauseReason(b *testing.B) {
 		err = e
 	}
 	b.StopTimer()
-	b_unused(err)
+	unused2(err)
 }

--- a/dax_base_test.go
+++ b/dax_base_test.go
@@ -1,0 +1,572 @@
+package sabi
+
+import (
+	"container/list"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+var logs list.List
+var WillFailToCreateFooDaxConn bool = false
+var WillFailToCommitFooDaxConn bool = false
+
+type /* error reason */ (
+	InvalidDaxConn struct{}
+)
+
+func ClearDaxBase() {
+	isGlobalDaxSrcsFixed = false
+	globalDaxSrcMap = make(map[string]DaxSrc)
+
+	logs.Init()
+
+	WillFailToCreateFooDaxConn = false
+	WillFailToCommitFooDaxConn = false
+}
+
+type FooDaxConn struct {
+	Label string
+}
+
+func (conn *FooDaxConn) Commit() Err {
+	if WillFailToCommitFooDaxConn {
+		return NewErr(InvalidDaxConn{})
+	}
+	logs.PushBack("FooDaxConn#Commit")
+	return Ok()
+}
+
+func (conn *FooDaxConn) Rollback() {
+	logs.PushBack("FooDaxConn#Rollback")
+}
+
+func (conn *FooDaxConn) Close() {
+	logs.PushBack("FooDaxConn#Close")
+}
+
+type FooDaxSrc struct {
+	Label string
+}
+
+func (ds FooDaxSrc) CreateDaxConn() (DaxConn, Err) {
+	if WillFailToCreateFooDaxConn {
+		return nil, NewErr(InvalidDaxConn{})
+	}
+	return &FooDaxConn{Label: ds.Label}, Ok()
+}
+
+type BarDaxConn struct {
+	Label string
+	store map[string]string
+}
+
+func (conn *BarDaxConn) Commit() Err {
+	logs.PushBack("BarDaxConn#Commit")
+	return Ok()
+}
+
+func (conn *BarDaxConn) Rollback() {
+	logs.PushBack("BarDaxConn#Rollback")
+}
+
+func (conn *BarDaxConn) Close() {
+	logs.PushBack("BarDaxConn#Close")
+}
+
+func (conn *BarDaxConn) Store(name, value string) {
+	conn.store[name] = value
+}
+
+type BarDaxSrc struct {
+	Label string
+	Store map[string]string
+}
+
+func (ds BarDaxSrc) CreateDaxConn() (DaxConn, Err) {
+	return &BarDaxConn{Label: ds.Label, store: ds.Store}, Ok()
+}
+
+func TestAddGlobalDaxSrc(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 0)
+
+	AddGlobalDaxSrc("foo", FooDaxSrc{})
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+
+	AddGlobalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 2)
+}
+
+func TestFixGlobalDaxSrcs(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 0)
+
+	AddGlobalDaxSrc("foo", FooDaxSrc{})
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+
+	FixGlobalDaxSrcs()
+
+	assert.True(t, isGlobalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+
+	AddGlobalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.True(t, isGlobalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+
+	isGlobalDaxSrcsFixed = false
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+
+	AddGlobalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 2)
+}
+
+func TestDaxBase_AddLocalDaxSrc(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.(*daxBaseImpl).isLocalDaxSrcsFixed = true
+
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.True(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.(*daxBaseImpl).isLocalDaxSrcsFixed = false
+
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+}
+
+func TestDaxBase_RemoveLocalDaxSrc(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.RemoveLocalDaxSrc("bar")
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.(*daxBaseImpl).isLocalDaxSrcsFixed = true
+
+	base.RemoveLocalDaxSrc("foo")
+
+	assert.True(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.(*daxBaseImpl).isLocalDaxSrcsFixed = false
+
+	base.RemoveLocalDaxSrc("foo")
+
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+}
+
+func TestDaxBase_begin(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 0)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	AddGlobalDaxSrc("foo", FooDaxSrc{})
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.begin()
+
+	assert.True(t, isGlobalDaxSrcsFixed)
+	assert.True(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	AddGlobalDaxSrc("bar", &BarDaxSrc{})
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.True(t, isGlobalDaxSrcsFixed)
+	assert.True(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	base.(*daxBaseImpl).isLocalDaxSrcsFixed = false
+
+	assert.True(t, isGlobalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	AddGlobalDaxSrc("bar", &BarDaxSrc{})
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.True(t, isGlobalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	isGlobalDaxSrcsFixed = false
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 1)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+
+	AddGlobalDaxSrc("bar", &BarDaxSrc{})
+
+	assert.False(t, isGlobalDaxSrcsFixed)
+	assert.False(t, base.(*daxBaseImpl).isLocalDaxSrcsFixed)
+	assert.Equal(t, len(globalDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).localDaxSrcMap), 2)
+	assert.Equal(t, len(base.(*daxBaseImpl).daxConnMap), 0)
+}
+
+func TestDaxBase_GetDaxConn_withLocalDaxSrc(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+
+	conn, err := base.GetDaxConn("foo")
+	assert.Nil(t, conn)
+	switch err.Reason().(type) {
+	case DaxSrcIsNotFound:
+		assert.Equal(t, err.Get("Name"), "foo")
+	default:
+		assert.Fail(t, err.Error())
+	}
+
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+
+	conn, err = base.GetDaxConn("foo")
+	assert.NotNil(t, conn)
+	assert.True(t, err.IsOk())
+
+	var conn2 DaxConn
+	conn2, err = base.GetDaxConn("foo")
+	assert.Equal(t, conn2, conn)
+	assert.True(t, err.IsOk())
+}
+
+func TestDaxBase_GetDaxConn_withGlobalDaxSrc(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+
+	conn, err := base.GetDaxConn("foo")
+	assert.Nil(t, conn)
+	switch err.Reason().(type) {
+	case DaxSrcIsNotFound:
+		assert.Equal(t, err.Get("Name"), "foo")
+	default:
+		assert.Fail(t, err.Error())
+	}
+
+	AddGlobalDaxSrc("foo", FooDaxSrc{})
+
+	conn, err = base.GetDaxConn("foo")
+	assert.NotNil(t, conn)
+	assert.True(t, err.IsOk())
+
+	var conn2 DaxConn
+	conn2, err = base.GetDaxConn("foo")
+	assert.Equal(t, conn2, conn)
+	assert.True(t, err.IsOk())
+}
+
+func TestDaxBase_GetDaxConn_localDsIsTakenPriorityOfGlobalDs(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+
+	conn, err := base.GetDaxConn("foo")
+	assert.Nil(t, conn)
+	switch err.Reason().(type) {
+	case DaxSrcIsNotFound:
+		assert.Equal(t, err.Get("Name"), "foo")
+	default:
+		assert.Fail(t, err.Error())
+	}
+
+	AddGlobalDaxSrc("foo", FooDaxSrc{Label: "global"})
+	FixGlobalDaxSrcs()
+
+	base.AddLocalDaxSrc("foo", FooDaxSrc{Label: "local"})
+
+	conn, err = base.GetDaxConn("foo")
+	assert.Equal(t, conn.(*FooDaxConn).Label, "local")
+	assert.True(t, err.IsOk())
+}
+
+func TestDaxBase_GetDaxConn_failToCreateDaxConn(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	WillFailToCreateFooDaxConn = true
+	defer func() { WillFailToCreateFooDaxConn = false }()
+
+	base := NewDaxBase()
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+
+	conn, err := base.GetDaxConn("foo")
+	assert.Nil(t, conn)
+	switch err.Reason().(type) {
+	case FailToCreateDaxConn:
+		assert.Equal(t, err.Get("Name"), "foo")
+		switch err.Cause().(Err).Reason().(type) {
+		case InvalidDaxConn:
+		default:
+			assert.Fail(t, err.Error())
+		}
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestDaxBase_commit(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+	base.begin()
+
+	fooConn, fooErr := base.GetDaxConn("foo")
+	assert.NotNil(t, fooConn)
+	assert.True(t, fooErr.IsOk())
+
+	barConn, barErr := base.GetDaxConn("bar")
+	assert.NotNil(t, barConn)
+	assert.True(t, barErr.IsOk())
+
+	err := base.commit()
+	assert.True(t, err.IsOk())
+
+	assert.Equal(t, logs.Len(), 2)
+	if logs.Front().Value == "FooDaxConn#Commit" {
+		assert.Equal(t, logs.Front().Value, "FooDaxConn#Commit")
+		assert.Equal(t, logs.Back().Value, "BarDaxConn#Commit")
+	} else {
+		assert.Equal(t, logs.Front().Value, "BarDaxConn#Commit")
+		assert.Equal(t, logs.Back().Value, "FooDaxConn#Commit")
+	}
+}
+
+func TestDaxBase_commit_failed(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+
+	base.begin()
+
+	fooConn, fooErr := base.GetDaxConn("foo")
+	assert.NotNil(t, fooConn)
+	assert.True(t, fooErr.IsOk())
+
+	barConn, barErr := base.GetDaxConn("bar")
+	assert.NotNil(t, barConn)
+	assert.True(t, barErr.IsOk())
+
+	WillFailToCommitFooDaxConn = true
+
+	err := base.commit()
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case FailToCommitDaxConn:
+		m := err.Get("Errors").(map[string]Err)
+		assert.Equal(t, m["foo"].ReasonName(), "InvalidDaxConn")
+	default:
+		assert.Fail(t, err.Error())
+	}
+
+	assert.Equal(t, logs.Len(), 1)
+	assert.Equal(t, logs.Back().Value, "BarDaxConn#Commit")
+}
+
+func TestDaxBase_rollback(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+	base.begin()
+
+	fooConn, fooErr := base.GetDaxConn("foo")
+	assert.NotNil(t, fooConn)
+	assert.True(t, fooErr.IsOk())
+
+	barConn, barErr := base.GetDaxConn("bar")
+	assert.NotNil(t, barConn)
+	assert.True(t, barErr.IsOk())
+
+	base.rollback()
+
+	assert.Equal(t, logs.Len(), 2)
+	if logs.Front().Value == "FooDaxConn#Rollback" {
+		assert.Equal(t, logs.Front().Value, "FooDaxConn#Rollback")
+		assert.Equal(t, logs.Back().Value, "BarDaxConn#Rollback")
+	} else {
+		assert.Equal(t, logs.Front().Value, "BarDaxConn#Rollback")
+		assert.Equal(t, logs.Back().Value, "FooDaxConn#Rollback")
+	}
+}
+
+func TestDaxBase_close(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+	base.begin()
+
+	fooConn, fooErr := base.GetDaxConn("foo")
+	assert.NotNil(t, fooConn)
+	assert.True(t, fooErr.IsOk())
+
+	barConn, barErr := base.GetDaxConn("bar")
+	assert.NotNil(t, barConn)
+	assert.True(t, barErr.IsOk())
+
+	base.end()
+
+	assert.Equal(t, logs.Len(), 2)
+	if logs.Front().Value == "FooDaxConn#Close" {
+		assert.Equal(t, logs.Front().Value, "FooDaxConn#Close")
+		assert.Equal(t, logs.Back().Value, "BarDaxConn#Close")
+	} else {
+		assert.Equal(t, logs.Front().Value, "BarDaxConn#Close")
+		assert.Equal(t, logs.Back().Value, "FooDaxConn#Close")
+	}
+}
+
+type FooDax struct {
+	Dax
+}
+
+func NewFooDax(dax Dax) FooDax {
+	return FooDax{Dax: dax}
+}
+
+func (dax FooDax) GetFooDaxConn(name string) (*FooDaxConn, Err) {
+	conn, err := dax.GetDaxConn(name)
+	if !err.IsOk() {
+		return nil, err
+	}
+	return conn.(*FooDaxConn), Ok()
+}
+
+type BarDax struct {
+	Dax
+}
+
+func NewBarDax(dax Dax) BarDax {
+	return BarDax{Dax: dax}
+}
+
+func (dax BarDax) GetBarDaxConn(name string) (*BarDaxConn, Err) {
+	conn, err := dax.GetDaxConn(name)
+	if !err.IsOk() {
+		return nil, err
+	}
+	return conn.(*BarDaxConn), Ok()
+}
+
+func TestDax_GetXxxConn(t *testing.T) {
+	ClearDaxBase()
+	defer ClearDaxBase()
+
+	base := NewDaxBase()
+	base.AddLocalDaxSrc("foo", FooDaxSrc{})
+	base.AddLocalDaxSrc("bar", &BarDaxSrc{})
+
+	base.begin()
+
+	fooDax := NewFooDax(base)
+	fooConn, fooErr := fooDax.GetFooDaxConn("foo")
+	assert.True(t, fooErr.IsOk())
+	assert.Equal(t, reflect.TypeOf(fooConn).String(), "*sabi.FooDaxConn")
+
+	barDax := NewBarDax(base)
+	barConn, barErr := barDax.GetBarDaxConn("bar")
+	assert.True(t, barErr.IsOk())
+	assert.Equal(t, reflect.TypeOf(barConn).String(), "*sabi.BarDaxConn")
+}

--- a/doc_test.go
+++ b/doc_test.go
@@ -1,0 +1,160 @@
+package sabi_test
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/sttk-go/sabi"
+	"testing"
+)
+
+type GreetDax interface {
+	UserName() (string, sabi.Err)
+	Say(greeting string) sabi.Err
+}
+
+type ( // possible error reasons
+	NoName       struct{}
+	FailToOutput struct{ Text string }
+)
+
+func GreetLogic(dax GreetDax) sabi.Err {
+	name, err := dax.UserName()
+	if !err.IsOk() {
+		return err
+	}
+	return dax.Say("Hello, " + name)
+}
+
+type mapGreetDax struct {
+	m map[string]any
+}
+
+func (dax mapGreetDax) UserName() (string, sabi.Err) {
+	username, exists := dax.m["username"]
+	if !exists {
+		return "", sabi.NewErr(NoName{})
+	}
+	return username.(string), sabi.Ok()
+}
+
+func (dax mapGreetDax) Say(greeting string) sabi.Err {
+	dax.m["greeting"] = greeting
+	return sabi.Ok()
+}
+
+func NewMapGreetDaxBase(m map[string]any) sabi.DaxBase {
+	base := sabi.NewDaxBase()
+	return struct {
+		sabi.DaxBase
+		mapGreetDax
+	}{
+		DaxBase:     base,
+		mapGreetDax: mapGreetDax{m: m},
+	}
+}
+
+func TestGreetLogic_unitTest(t *testing.T) {
+	m := make(map[string]any)
+	base := NewMapGreetDaxBase(m)
+
+	m["username"] = "World"
+	err := sabi.RunTxn(base, GreetLogic)
+	assert.True(t, err.IsOk())
+	assert.Equal(t, m["greeting"], "Hello, World")
+}
+
+var osArgs []string
+
+type CliArgsUserDax struct {
+}
+
+func (dax CliArgsUserDax) UserName() (string, sabi.Err) {
+	if len(osArgs) <= 1 {
+		return "", sabi.NewErr(NoName{})
+	}
+	return osArgs[1], sabi.Ok()
+}
+
+type ConsoleOutputDax struct {
+}
+
+func (dax ConsoleOutputDax) Say(text string) sabi.Err {
+	_, e := fmt.Println(text)
+	if e != nil {
+		return sabi.NewErr(FailToOutput{Text: text}, e)
+	}
+	return sabi.Ok()
+}
+
+func NewGreetDaxBase() sabi.DaxBase {
+	base := sabi.NewDaxBase()
+	return struct {
+		sabi.DaxBase
+		CliArgsUserDax
+		ConsoleOutputDax
+	}{
+		DaxBase:          base,
+		CliArgsUserDax:   CliArgsUserDax{},
+		ConsoleOutputDax: ConsoleOutputDax{},
+	}
+}
+
+func TestGreetLogic_executingLogic(t *testing.T) {
+	osArgs = []string{"cmd", "Tom"}
+	base := NewGreetDaxBase()
+	err := sabi.RunTxn(base, GreetLogic)
+	assert.True(t, err.IsOk())
+}
+
+type PrintDax interface {
+	Print() sabi.Err
+}
+
+type ConsoleOutputDax2 struct {
+	text string
+}
+
+func (dax *ConsoleOutputDax2) Say(text string) sabi.Err {
+	dax.text = text
+	return sabi.Ok()
+}
+func (dax *ConsoleOutputDax2) Print() sabi.Err {
+	_, e := fmt.Println(dax.text)
+	if e != nil {
+		return sabi.NewErr(FailToOutput{Text: dax.text}, e)
+	}
+	return sabi.Ok()
+}
+
+func NewGreetDaxBase2() sabi.DaxBase {
+	base := sabi.NewDaxBase()
+	return struct {
+		sabi.DaxBase
+		CliArgsUserDax
+		*ConsoleOutputDax2
+	}{
+		DaxBase:           base,
+		CliArgsUserDax:    CliArgsUserDax{},
+		ConsoleOutputDax2: &ConsoleOutputDax2{},
+	}
+}
+
+func TestGreetLogic_MovingOutputs(t *testing.T) {
+	base := NewGreetDaxBase2()
+	err := sabi.RunTxn(base, GreetLogic)
+	assert.True(t, err.IsOk())
+	err = sabi.RunTxn(base, func(dax PrintDax) sabi.Err {
+		return dax.Print()
+	})
+	assert.True(t, err.IsOk())
+}
+
+func TestGreetLogic_MovingOutputs2(t *testing.T) {
+	base := NewGreetDaxBase2()
+	txn0 := sabi.Txn(base, GreetLogic)
+	txn1 := sabi.Txn(base, func(dax PrintDax) sabi.Err {
+		return dax.Print()
+	})
+	err := sabi.RunSeq(txn0, txn1)
+	assert.True(t, err.IsOk())
+}

--- a/example_runner_test.go
+++ b/example_runner_test.go
@@ -9,16 +9,23 @@ type BazDax interface {
 	SetData(data string)
 }
 
+type bazDaxImpl struct {
+}
+
+func (dax bazDaxImpl) GetData() string {
+	return ""
+}
+func (dax bazDaxImpl) SetData(data string) {
+}
+
 var base0 = sabi.NewDaxBase()
 
 var base = struct {
 	sabi.DaxBase
-	FooGetterDax
-	BarSetterDax
+	bazDaxImpl
 }{
-	DaxBase:      base0,
-	FooGetterDax: FooGetterDax{Dax: base0},
-	BarSetterDax: BarSetterDax{Dax: base0},
+	DaxBase:    base0,
+	bazDaxImpl: bazDaxImpl{},
 }
 
 func ExamplePara() {
@@ -32,7 +39,6 @@ func ExamplePara() {
 	// Output:
 
 	unused(err)
-	sabi.Clear()
 }
 
 func ExampleSeq() {
@@ -46,7 +52,6 @@ func ExampleSeq() {
 	// Output:
 
 	unused(err)
-	sabi.Clear()
 }
 
 func ExampleRunPara() {
@@ -58,7 +63,6 @@ func ExampleRunPara() {
 	// Output:
 
 	unused(err)
-	sabi.Clear()
 }
 
 func ExampleRunSeq() {
@@ -70,5 +74,4 @@ func ExampleRunSeq() {
 	// Output:
 
 	unused(err)
-	sabi.Clear()
 }

--- a/notify_test.go
+++ b/notify_test.go
@@ -173,14 +173,17 @@ func TestNotifyErr_withHandlers(t *testing.T) {
 	AddSyncErrHandler(func(err Err, occ ErrOccasion) {
 		syncLogs.PushBack(
 			err.ReasonName() + "-1:" + occ.File() + ":" + strconv.Itoa(occ.Line()))
+		occ.Time()
 	})
 	AddSyncErrHandler(func(err Err, occ ErrOccasion) {
 		syncLogs.PushBack(
 			err.ReasonName() + "-2:" + occ.File() + ":" + strconv.Itoa(occ.Line()))
+		occ.Time()
 	})
 	AddAsyncErrHandler(func(err Err, occ ErrOccasion) {
 		asyncLogs.PushBack(
 			err.ReasonName() + "-3:" + occ.File() + ":" + strconv.Itoa(occ.Line()))
+		occ.Time()
 	})
 
 	NewErr(ReasonForNotification{})
@@ -198,13 +201,13 @@ func TestNotifyErr_withHandlers(t *testing.T) {
 
 	assert.Equal(t, syncLogs.Len(), 2)
 	assert.Equal(t, syncLogs.Front().Value,
-		"ReasonForNotification-1:notify_test.go:195")
+		"ReasonForNotification-1:notify_test.go:198")
 	assert.Equal(t, syncLogs.Front().Next().Value,
-		"ReasonForNotification-2:notify_test.go:195")
+		"ReasonForNotification-2:notify_test.go:198")
 
 	time.Sleep(100 * time.Millisecond)
 
 	assert.Equal(t, asyncLogs.Len(), 1)
 	assert.Equal(t, asyncLogs.Front().Value,
-		"ReasonForNotification-3:notify_test.go:195")
+		"ReasonForNotification-3:notify_test.go:198")
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -14,11 +14,11 @@ type (
 	}
 )
 
-var logs list.List
+var runnerLogs list.List
 var errorRunnerName string
 
-func ClearLogs() {
-	logs.Init()
+func clearLogs() {
+	runnerLogs.Init()
 	errorRunnerName = ""
 }
 
@@ -32,13 +32,13 @@ func (r MyRunner) Run() sabi.Err {
 	if r.Name == errorRunnerName {
 		return sabi.NewErr(FailToRun{Name: r.Name})
 	}
-	logs.PushBack(r.Name)
+	runnerLogs.PushBack(r.Name)
 	return sabi.Ok()
 }
 
 func TestSeq(t *testing.T) {
-	ClearLogs()
-	defer ClearLogs()
+	clearLogs()
+	defer clearLogs()
 
 	r0 := MyRunner{Name: "r-0", Wait: 50 * time.Millisecond}
 	r1 := MyRunner{Name: "r-1", Wait: 10 * time.Millisecond}
@@ -48,15 +48,15 @@ func TestSeq(t *testing.T) {
 	err := r3.Run()
 	assert.True(t, err.IsOk())
 
-	assert.Equal(t, logs.Len(), 3)
-	assert.Equal(t, logs.Front().Value, "r-0")
-	assert.Equal(t, logs.Front().Next().Value, "r-1")
-	assert.Equal(t, logs.Front().Next().Next().Value, "r-2")
+	assert.Equal(t, runnerLogs.Len(), 3)
+	assert.Equal(t, runnerLogs.Front().Value, "r-0")
+	assert.Equal(t, runnerLogs.Front().Next().Value, "r-1")
+	assert.Equal(t, runnerLogs.Front().Next().Next().Value, "r-2")
 }
 
 func TestSeq_FailToRun(t *testing.T) {
-	ClearLogs()
-	defer ClearLogs()
+	clearLogs()
+	defer clearLogs()
 
 	errorRunnerName = "r-1"
 
@@ -74,13 +74,13 @@ func TestSeq_FailToRun(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 
-	assert.Equal(t, logs.Len(), 1)
-	assert.Equal(t, logs.Front().Value, "r-0")
+	assert.Equal(t, runnerLogs.Len(), 1)
+	assert.Equal(t, runnerLogs.Front().Value, "r-0")
 }
 
 func TestPara(t *testing.T) {
-	ClearLogs()
-	defer ClearLogs()
+	clearLogs()
+	defer clearLogs()
 
 	r0 := MyRunner{Name: "r-0", Wait: 50 * time.Millisecond}
 	r1 := MyRunner{Name: "r-1", Wait: 10 * time.Millisecond}
@@ -90,15 +90,15 @@ func TestPara(t *testing.T) {
 	err := r3.Run()
 	assert.True(t, err.IsOk())
 
-	assert.Equal(t, logs.Len(), 3)
-	assert.Equal(t, logs.Front().Value, "r-1")
-	assert.Equal(t, logs.Front().Next().Value, "r-2")
-	assert.Equal(t, logs.Front().Next().Next().Value, "r-0")
+	assert.Equal(t, runnerLogs.Len(), 3)
+	assert.Equal(t, runnerLogs.Front().Value, "r-1")
+	assert.Equal(t, runnerLogs.Front().Next().Value, "r-2")
+	assert.Equal(t, runnerLogs.Front().Next().Next().Value, "r-0")
 }
 
 func TestPara_FailToRun(t *testing.T) {
-	ClearLogs()
-	defer ClearLogs()
+	clearLogs()
+	defer clearLogs()
 
 	errorRunnerName = "r-1"
 
@@ -118,14 +118,14 @@ func TestPara_FailToRun(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 
-	assert.Equal(t, logs.Len(), 2)
-	assert.Equal(t, logs.Front().Value, "r-2")
-	assert.Equal(t, logs.Front().Next().Value, "r-0")
+	assert.Equal(t, runnerLogs.Len(), 2)
+	assert.Equal(t, runnerLogs.Front().Value, "r-2")
+	assert.Equal(t, runnerLogs.Front().Next().Value, "r-0")
 }
 
 func TestRunSeq(t *testing.T) {
-	ClearLogs()
-	defer ClearLogs()
+	clearLogs()
+	defer clearLogs()
 
 	r0 := MyRunner{Name: "r-0", Wait: 50 * time.Millisecond}
 	r1 := MyRunner{Name: "r-1", Wait: 10 * time.Millisecond}
@@ -134,15 +134,15 @@ func TestRunSeq(t *testing.T) {
 	err := sabi.RunSeq(r0, r1, r2)
 	assert.True(t, err.IsOk())
 
-	assert.Equal(t, logs.Len(), 3)
-	assert.Equal(t, logs.Front().Value, "r-0")
-	assert.Equal(t, logs.Front().Next().Value, "r-1")
-	assert.Equal(t, logs.Front().Next().Next().Value, "r-2")
+	assert.Equal(t, runnerLogs.Len(), 3)
+	assert.Equal(t, runnerLogs.Front().Value, "r-0")
+	assert.Equal(t, runnerLogs.Front().Next().Value, "r-1")
+	assert.Equal(t, runnerLogs.Front().Next().Next().Value, "r-2")
 }
 
 func TestRunSeq_FailToRun(t *testing.T) {
-	ClearLogs()
-	defer ClearLogs()
+	clearLogs()
+	defer clearLogs()
 
 	errorRunnerName = "r-1"
 
@@ -160,13 +160,13 @@ func TestRunSeq_FailToRun(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 
-	assert.Equal(t, logs.Len(), 1)
-	assert.Equal(t, logs.Front().Value, "r-0")
+	assert.Equal(t, runnerLogs.Len(), 1)
+	assert.Equal(t, runnerLogs.Front().Value, "r-0")
 }
 
 func TestRunPara(t *testing.T) {
-	ClearLogs()
-	defer ClearLogs()
+	clearLogs()
+	defer clearLogs()
 
 	r0 := MyRunner{Name: "r-0", Wait: 50 * time.Millisecond}
 	r1 := MyRunner{Name: "r-1", Wait: 10 * time.Millisecond}
@@ -175,15 +175,15 @@ func TestRunPara(t *testing.T) {
 	err := sabi.RunPara(r0, r1, r2)
 	assert.True(t, err.IsOk())
 
-	assert.Equal(t, logs.Len(), 3)
-	assert.Equal(t, logs.Front().Value, "r-1")
-	assert.Equal(t, logs.Front().Next().Value, "r-2")
-	assert.Equal(t, logs.Front().Next().Next().Value, "r-0")
+	assert.Equal(t, runnerLogs.Len(), 3)
+	assert.Equal(t, runnerLogs.Front().Value, "r-1")
+	assert.Equal(t, runnerLogs.Front().Next().Value, "r-2")
+	assert.Equal(t, runnerLogs.Front().Next().Next().Value, "r-0")
 }
 
 func TestRunPara_FailToRun(t *testing.T) {
-	ClearLogs()
-	defer ClearLogs()
+	clearLogs()
+	defer clearLogs()
 
 	errorRunnerName = "r-1"
 
@@ -203,7 +203,7 @@ func TestRunPara_FailToRun(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 
-	assert.Equal(t, logs.Len(), 2)
-	assert.Equal(t, logs.Front().Value, "r-2")
-	assert.Equal(t, logs.Front().Next().Value, "r-0")
+	assert.Equal(t, runnerLogs.Len(), 2)
+	assert.Equal(t, runnerLogs.Front().Value, "r-2")
+	assert.Equal(t, runnerLogs.Front().Next().Value, "r-0")
 }


### PR DESCRIPTION
### Changes:

1. `benchmark_err_test.go`, `benchmark_notify_test.go`

    This PR has changed `b_unused` function to `unused` (in `benchmark_err_test.go`) and `unused2` (in `benchmark_notify_test.go`).

2. `dax_base_test.go`, `dax_test.go`

    This PR has moved tests of `DaxBase` to `dax_base_test.go` and has changed tests in `dax_test.go` to use `MapDaxSrc`, `MapDaxConn`, and `MapDax`.

3. `doc.go` and `doc_test.go`

    This PR has changed example codes and descriptions in `doc.go`, and has added tests in `doc_test.go` file to verify the example codes.

5. `example_dax_test.go`, `example_runner_test.go`, 

    This PR has changed example codes about dax and runners.

6. `notify_test.go`

    This PR has modified to increase the coverage of `notify.go` file. 

7. `runner_test.go`

    This PR has changed only the names: `logs` --> `runnerLogs`, `ClearLogs` --> `clearLogs`

8. `txn_test.go`

    This PR has modified to verify mapping of multiple dax interfaces and dax implementations.