### PR TITLE
new: added StartUpGlobalDaxSrcs and ShutdownGlobalDaxSrcs

### DIFF
--- a/dax.go
+++ b/dax.go
@@ -9,6 +9,15 @@ import (
 )
 
 type /* error reasons */ (
+	// FailToStartUpGlobalDaxSrcs is an error reason which indicates that some
+	// dax sources failed to start up.
+	// The field: Errors is a map of which keys are the registered names of
+	// DaxSrc(s) which failed to start up, and of which values are Err having
+	// their error reasons.
+	FailToStartUpGlobalDaxSrcs struct {
+		Errors map[string]Err
+	}
+
 	// DaxSrcIsNotFound is an error reason which indicates that a specified data
 	// source is not found.
 	// The field: Name is a registered name of a DaxSrc not found.
@@ -47,8 +56,12 @@ type DaxConn interface {
 // data store.
 // This interface defines a method: CreateDaxConn to creates a DaxConn instance
 // and returns its pointer.
+// This interface also defines methods: StartUp and Shutdown, which are for
+// initialization and termination of this DaxSrc instnace.
 type DaxSrc interface {
 	CreateDaxConn() (DaxConn, Err)
+	StartUp() Err
+	Shutdown()
 }
 
 // Dax is an interface for a set of data access methods.
@@ -87,9 +100,56 @@ func AddGlobalDaxSrc(name string, ds DaxSrc) {
 	}
 }
 
-// FixGlobalDaxSrcs makes unable to register any further global DaxSrc.
-func FixGlobalDaxSrcs() {
+// StartUpGlobalDaxSrcs is a function to forbid adding more global dax sources
+// and to initialize registered global dax sources by calling StartUp method of
+// each DaxSrc.
+// If even one DaxSrc fail to execute its StartUp method, this function
+// executes Shutdown methods of all global DaxSrc(s) and returns sabi.Err.
+func StartUpGlobalDaxSrcs() Err {
 	isGlobalDaxSrcsFixed = true
+
+	ch := make(chan namedErr)
+
+	for name, ds := range globalDaxSrcMap {
+		go func(name string, ds DaxSrc, ch chan namedErr) {
+			err := ds.StartUp()
+			ne := namedErr{name: name, err: err}
+			ch <- ne
+		}(name, ds, ch)
+	}
+
+	errs := make(map[string]Err)
+	n := len(globalDaxSrcMap)
+	for i := 0; i < n; i++ {
+		select {
+		case ne := <-ch:
+			if !ne.err.IsOk() {
+				errs[ne.name] = ne.err
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		ShutdownGlobalDaxSrcs()
+		return NewErr(FailToStartUpGlobalDaxSrcs{Errors: errs})
+	}
+
+	return Ok()
+}
+
+// ShutdownGlobalDaxSrcs is a function to terminate all global dax sources.
+func ShutdownGlobalDaxSrcs() {
+	var wg sync.WaitGroup
+	wg.Add(len(globalDaxSrcMap))
+
+	for _, ds := range globalDaxSrcMap {
+		go func(ds DaxSrc) {
+			defer wg.Done()
+			ds.Shutdown()
+		}(ds)
+	}
+
+	wg.Wait()
 }
 
 // DaxBase is an interface which works as a front of an implementation as a

--- a/dax.go
+++ b/dax.go
@@ -57,7 +57,7 @@ type DaxConn interface {
 // This interface defines a method: CreateDaxConn to creates a DaxConn instance
 // and returns its pointer.
 // This interface also defines methods: StartUp and Shutdown, which are for
-// initialization and termination of this DaxSrc instnace.
+// initialization and termination of this DaxSrc instance.
 type DaxSrc interface {
 	CreateDaxConn() (DaxConn, Err)
 	StartUp() Err

--- a/dax_test.go
+++ b/dax_test.go
@@ -20,6 +20,13 @@ func (ds MapDaxSrc) CreateDaxConn() (sabi.DaxConn, sabi.Err) {
 	return &MapDaxConn{dataMap: ds.dataMap}, sabi.Ok()
 }
 
+func (ds MapDaxSrc) StartUp() sabi.Err {
+	return sabi.Ok()
+}
+
+func (ds MapDaxSrc) Shutdown() {
+}
+
 //// MapDaxConn
 
 type MapDaxConn struct {

--- a/example_dax_test.go
+++ b/example_dax_test.go
@@ -28,9 +28,14 @@ func ExampleAddGlobalDaxSrc() {
 	sabi.ClearDaxBase()
 }
 
-func ExampleFixGlobalDaxSrcs() {
+func ExampleStartUpGlobalDaxSrcs() {
 	sabi.AddGlobalDaxSrc("hoge", NewMapDaxSrc())
-	sabi.FixGlobalDaxSrcs()
+
+	if err := sabi.StartUpGlobalDaxSrcs(); !err.IsOk() {
+		return
+	}
+	defer sabi.ShutdownGlobalDaxSrcs()
+
 	sabi.AddGlobalDaxSrc("fuga", NewMapDaxSrc())
 
 	base := sabi.NewDaxBase()

--- a/txn_test.go
+++ b/txn_test.go
@@ -42,6 +42,13 @@ func (ds ADaxSrc) CreateDaxConn() (sabi.DaxConn, sabi.Err) {
 	return &ADaxConn{AMap: ds.AMap}, sabi.Ok()
 }
 
+func (ds ADaxSrc) StartUp() sabi.Err {
+	return sabi.Ok()
+}
+
+func (ds ADaxSrc) Shutdown() {
+}
+
 type ADaxConn struct {
 	AMap map[string]string
 }
@@ -84,6 +91,13 @@ func (ds BDaxSrc) CreateDaxConn() (sabi.DaxConn, sabi.Err) {
 	return &BDaxConn{BMap: ds.BMap}, sabi.Ok()
 }
 
+func (ds BDaxSrc) StartUp() sabi.Err {
+	return sabi.Ok()
+}
+
+func (ds BDaxSrc) Shutdown() {
+}
+
 type BDaxConn struct {
 	BMap map[string]string
 }
@@ -124,6 +138,13 @@ func NewCDaxSrc() CDaxSrc {
 
 func (ds CDaxSrc) CreateDaxConn() (sabi.DaxConn, sabi.Err) {
 	return &CDaxConn{CMap: ds.CMap}, sabi.Ok()
+}
+
+func (ds CDaxSrc) StartUp() sabi.Err {
+	return sabi.Ok()
+}
+
+func (ds CDaxSrc) Shutdown() {
 }
 
 type CDaxConn struct {


### PR DESCRIPTION
This PR adds `StartUpGlobalDaxSrcs` and `ShutdownGlobalDaxSrcs` function to initialize and terminate registered dax sources.
In addition, this PR adds `StartUp` and `Shutdown` method to `DaxSrc`.

See #34