### PR TITLE
update!: changed methods to add and remove local DaxSrc(s)

### DIFF
--- a/dax_test.go
+++ b/dax_test.go
@@ -20,11 +20,11 @@ func (ds MapDaxSrc) CreateDaxConn() (sabi.DaxConn, sabi.Err) {
 	return &MapDaxConn{dataMap: ds.dataMap}, sabi.Ok()
 }
 
-func (ds MapDaxSrc) StartUp() sabi.Err {
+func (ds MapDaxSrc) SetUp() sabi.Err {
 	return sabi.Ok()
 }
 
-func (ds MapDaxSrc) Shutdown() {
+func (ds MapDaxSrc) End() {
 }
 
 //// MapDaxConn
@@ -190,9 +190,9 @@ func TestDax_runTxn(t *testing.T) {
 	piyoDs := NewMapDaxSrc()
 
 	base := NewHogeFugaPiyoDaxBase()
-	base.AddLocalDaxSrc("hoge", hogeDs)
-	base.AddLocalDaxSrc("fuga", fugaDs)
-	base.AddLocalDaxSrc("piyo", piyoDs)
+	base.SetUpLocalDaxSrc("hoge", hogeDs)
+	base.SetUpLocalDaxSrc("fuga", fugaDs)
+	base.SetUpLocalDaxSrc("piyo", piyoDs)
 
 	hogeDs.dataMap["hogehoge"] = "Hello, world"
 

--- a/example_dax_test.go
+++ b/example_dax_test.go
@@ -65,9 +65,9 @@ func ExampleStartUpGlobalDaxSrcs() {
 	sabi.ClearDaxBase()
 }
 
-func ExampleDaxBase_AddLocalDaxSrc() {
+func ExampleDaxBase_SetUpLocalDaxSrc() {
 	base := sabi.NewDaxBase()
-	base.AddLocalDaxSrc("hoge", NewMapDaxSrc())
+	base.SetUpLocalDaxSrc("hoge", NewMapDaxSrc())
 
 	type MyDax struct {
 		sabi.Dax
@@ -140,8 +140,8 @@ func ExampleDax() {
 	fugaDs := NewMapDaxSrc()
 
 	base := sabi.NewDaxBase()
-	base.AddLocalDaxSrc("hoge", hogeDs)
-	base.AddLocalDaxSrc("fuga", fugaDs)
+	base.SetUpLocalDaxSrc("hoge", hogeDs)
+	base.SetUpLocalDaxSrc("fuga", fugaDs)
 
 	base = struct {
 		sabi.DaxBase

--- a/txn_test.go
+++ b/txn_test.go
@@ -42,11 +42,11 @@ func (ds ADaxSrc) CreateDaxConn() (sabi.DaxConn, sabi.Err) {
 	return &ADaxConn{AMap: ds.AMap}, sabi.Ok()
 }
 
-func (ds ADaxSrc) StartUp() sabi.Err {
+func (ds ADaxSrc) SetUp() sabi.Err {
 	return sabi.Ok()
 }
 
-func (ds ADaxSrc) Shutdown() {
+func (ds ADaxSrc) End() {
 }
 
 type ADaxConn struct {
@@ -91,11 +91,11 @@ func (ds BDaxSrc) CreateDaxConn() (sabi.DaxConn, sabi.Err) {
 	return &BDaxConn{BMap: ds.BMap}, sabi.Ok()
 }
 
-func (ds BDaxSrc) StartUp() sabi.Err {
+func (ds BDaxSrc) SetUp() sabi.Err {
 	return sabi.Ok()
 }
 
-func (ds BDaxSrc) Shutdown() {
+func (ds BDaxSrc) End() {
 }
 
 type BDaxConn struct {
@@ -140,11 +140,11 @@ func (ds CDaxSrc) CreateDaxConn() (sabi.DaxConn, sabi.Err) {
 	return &CDaxConn{CMap: ds.CMap}, sabi.Ok()
 }
 
-func (ds CDaxSrc) StartUp() sabi.Err {
+func (ds CDaxSrc) SetUp() sabi.Err {
 	return sabi.Ok()
 }
 
-func (ds CDaxSrc) Shutdown() {
+func (ds CDaxSrc) End() {
 }
 
 type CDaxConn struct {
@@ -247,8 +247,8 @@ func TestRunTxn(t *testing.T) {
 
 	aDs := NewADaxSrc()
 	bDs := NewBDaxSrc()
-	base.AddLocalDaxSrc("aaa", aDs)
-	base.AddLocalDaxSrc("bbb", bDs)
+	base.SetUpLocalDaxSrc("aaa", aDs)
+	base.SetUpLocalDaxSrc("bbb", bDs)
 
 	aDs.AMap["a"] = "hello"
 	err := sabi.RunTxn(base, func(dax ABDax) sabi.Err {
@@ -305,8 +305,8 @@ func TestRunTxn_failToCreateDaxConn(t *testing.T) {
 
 	aDs := NewADaxSrc()
 	bDs := NewBDaxSrc()
-	base.AddLocalDaxSrc("aaa", aDs)
-	base.AddLocalDaxSrc("bbb", bDs)
+	base.SetUpLocalDaxSrc("aaa", aDs)
+	base.SetUpLocalDaxSrc("bbb", bDs)
 
 	aDs.AMap["a"] = "hello"
 	err := sabi.RunTxn(base, func(dax ABDax) sabi.Err {
@@ -362,8 +362,8 @@ func TestRunTxn_failToCommitDaxConn(t *testing.T) {
 
 	aDs := NewADaxSrc()
 	bDs := NewBDaxSrc()
-	base.AddLocalDaxSrc("aaa", aDs)
-	base.AddLocalDaxSrc("bbb", bDs)
+	base.SetUpLocalDaxSrc("aaa", aDs)
+	base.SetUpLocalDaxSrc("bbb", bDs)
 
 	aDs.AMap["a"] = "hello"
 	err := sabi.RunTxn(base, func(dax ABDax) sabi.Err {
@@ -435,8 +435,8 @@ func TestRunTxn_Run_errorInLogic(t *testing.T) {
 
 	aDs := NewADaxSrc()
 	bDs := NewBDaxSrc()
-	base.AddLocalDaxSrc("aaa", aDs)
-	base.AddLocalDaxSrc("bbb", bDs)
+	base.SetUpLocalDaxSrc("aaa", aDs)
+	base.SetUpLocalDaxSrc("bbb", bDs)
 
 	aDs.AMap["a"] = "hello"
 	err := sabi.RunTxn(base, func(dax ABDax) sabi.Err {


### PR DESCRIPTION
This PR changes something as follows:

1. Renames `DaxSrc` methods `StartUp` to `SetUp` and `Shutdown` to `End`.
2. Renames `DaxBase` methods `AddLocalDaxSrc` to `SetUpLocalDaxSrc`, `RemoveLocalDaxSrc` to `FreeLocalDaxSrc`.
3. Adds a `DaxBase` method `FreeAllLocalDaxSrcs`, which releases all regisered local DacSrc(s).