### PR TITLE
new!: added GetDaxConn function and hid Dax#GetDaxConn

### DIFF
--- a/dax_dummy_for_test.go
+++ b/dax_dummy_for_test.go
@@ -93,16 +93,16 @@ type BarDaxConn struct {
 	Map   map[string]string
 }
 
-func (conn BarDaxConn) Commit() sabi.Err {
+func (conn *BarDaxConn) Commit() sabi.Err {
 	Logs.PushBack("BarDaxConn#Commit")
 	return sabi.Ok()
 }
 
-func (conn BarDaxConn) Rollback() {
+func (conn *BarDaxConn) Rollback() {
 	Logs.PushBack("BarDaxConn#Rollback")
 }
 
-func (conn BarDaxConn) Close() {
+func (conn *BarDaxConn) Close() {
 	Logs.PushBack("BarDaxConn#Close")
 }
 
@@ -114,7 +114,7 @@ type BarDaxSrc struct {
 
 func (ds BarDaxSrc) CreateDaxConn() (sabi.DaxConn, sabi.Err) {
 	Logs.PushBack("BarDaxSrc#CreateDaxConn")
-	return BarDaxConn{Label: ds.Label, Map: make(map[string]string)}, sabi.Ok()
+	return &BarDaxConn{Label: ds.Label, Map: make(map[string]string)}, sabi.Ok()
 }
 
 func (ds BarDaxSrc) SetUp() sabi.Err {
@@ -163,24 +163,6 @@ func (conn MapDaxConn) Rollback() {
 func (conn MapDaxConn) Close() {
 }
 
-// MapDax
-
-type MapDax struct {
-	sabi.Dax
-}
-
-func NewMapDax(base sabi.DaxBase) MapDax {
-	return MapDax{Dax: base}
-}
-
-func (dax MapDax) GetMapDaxConn(name string) (MapDaxConn, sabi.Err) {
-	conn, err := dax.GetDaxConn(name)
-	if err.IsNotOk() {
-		return MapDaxConn{}, err
-	}
-	return conn.(MapDaxConn), err
-}
-
 // HogeFugaDax
 
 type HogeFugaDax interface {
@@ -220,11 +202,11 @@ func FugaPiyoLogic(dax FugaPiyoDax) sabi.Err {
 // HogeDax
 
 type HogeDax struct {
-	MapDax
+	sabi.Dax
 }
 
 func (dax HogeDax) GetHogeData() (string, sabi.Err) {
-	conn, err := dax.GetMapDaxConn("hoge")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "hoge")
 	if err.IsNotOk() {
 		return "", err
 	}
@@ -233,7 +215,7 @@ func (dax HogeDax) GetHogeData() (string, sabi.Err) {
 }
 
 func (dax HogeDax) SetHogeData(data string) sabi.Err {
-	conn, err := dax.GetMapDaxConn("hoge")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "hoge")
 	if err.IsNotOk() {
 		return err
 	}
@@ -244,11 +226,11 @@ func (dax HogeDax) SetHogeData(data string) sabi.Err {
 // FugaDax
 
 type FugaDax struct {
-	MapDax
+	sabi.Dax
 }
 
 func (dax FugaDax) GetFugaData() (string, sabi.Err) {
-	conn, err := dax.GetMapDaxConn("fuga")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "fuga")
 	if err.IsNotOk() {
 		return "", err
 	}
@@ -257,7 +239,7 @@ func (dax FugaDax) GetFugaData() (string, sabi.Err) {
 }
 
 func (dax FugaDax) SetFugaData(data string) sabi.Err {
-	conn, err := dax.GetMapDaxConn("fuga")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "fuga")
 	if err.IsNotOk() {
 		return err
 	}
@@ -268,11 +250,11 @@ func (dax FugaDax) SetFugaData(data string) sabi.Err {
 // PiyoDax
 
 type PiyoDax struct {
-	MapDax
+	sabi.Dax
 }
 
 func (dax PiyoDax) GetPiyoData() (string, sabi.Err) {
-	conn, err := dax.GetMapDaxConn("piyo")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "piyo")
 	if err.IsNotOk() {
 		return "", err
 	}
@@ -281,7 +263,7 @@ func (dax PiyoDax) GetPiyoData() (string, sabi.Err) {
 }
 
 func (dax PiyoDax) SetPiyoData(data string) sabi.Err {
-	conn, err := dax.GetMapDaxConn("piyo")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "piyo")
 	if err.IsNotOk() {
 		return err
 	}
@@ -300,9 +282,9 @@ func NewHogeFugaPiyoDaxBase() sabi.DaxBase {
 		PiyoDax
 	}{
 		DaxBase: base,
-		HogeDax: HogeDax{MapDax: NewMapDax(base)},
-		FugaDax: FugaDax{MapDax: NewMapDax(base)},
-		PiyoDax: PiyoDax{MapDax: NewMapDax(base)},
+		HogeDax: HogeDax{Dax: base},
+		FugaDax: FugaDax{Dax: base},
+		PiyoDax: PiyoDax{Dax: base},
 	}
 }
 
@@ -344,20 +326,6 @@ func (conn ADaxConn) Rollback() {
 
 func (conn ADaxConn) Close() {
 	Logs.PushBack("ADaxConn#Close")
-}
-
-// ADax
-
-type ADax struct {
-	sabi.Dax
-}
-
-func (dax ADax) GetADaxConn(name string) (ADaxConn, sabi.Err) {
-	conn, err := dax.GetDaxConn(name)
-	if err.IsNotOk() {
-		return ADaxConn{}, err
-	}
-	return conn.(ADaxConn), err
 }
 
 // BDaxSrc
@@ -406,20 +374,6 @@ func (conn BDaxConn) Close() {
 	Logs.PushBack("BDaxConn#Close")
 }
 
-// BDax
-
-type BDax struct {
-	sabi.Dax
-}
-
-func (dax BDax) GetBDaxConn(name string) (BDaxConn, sabi.Err) {
-	conn, err := dax.GetDaxConn(name)
-	if err.IsNotOk() {
-		return BDaxConn{}, err
-	}
-	return conn.(BDaxConn), err
-}
-
 // CDaxSrc
 
 type CDaxSrc struct {
@@ -460,28 +414,14 @@ func (conn CDaxConn) Close() {
 	Logs.PushBack("CDaxConn#Close")
 }
 
-// CDax
-
-type CDax struct {
-	sabi.Dax
-}
-
-func (dax CDax) GetCDaxConn(name string) (CDaxConn, sabi.Err) {
-	conn, err := dax.GetDaxConn(name)
-	if err.IsNotOk() {
-		return CDaxConn{}, err
-	}
-	return conn.(CDaxConn), err
-}
-
 // AGetDax
 
 type AGetDax struct {
-	ADax
+	sabi.Dax
 }
 
 func (dax AGetDax) GetAData() (string, sabi.Err) {
-	conn, err := dax.GetADaxConn("aaa")
+	conn, err := sabi.GetDaxConn[ADaxConn](dax, "aaa")
 	if !err.IsOk() {
 		return "", err
 	}
@@ -492,11 +432,11 @@ func (dax AGetDax) GetAData() (string, sabi.Err) {
 // BGetSetDax
 
 type BGetSetDax struct {
-	BDax
+	sabi.Dax
 }
 
 func (dax BGetSetDax) GetBData() (string, sabi.Err) {
-	conn, err := dax.GetBDaxConn("bbb")
+	conn, err := sabi.GetDaxConn[BDaxConn](dax, "bbb")
 	if !err.IsOk() {
 		return "", err
 	}
@@ -505,7 +445,7 @@ func (dax BGetSetDax) GetBData() (string, sabi.Err) {
 }
 
 func (dax BGetSetDax) SetBData(data string) sabi.Err {
-	conn, err := dax.GetBDaxConn("bbb")
+	conn, err := sabi.GetDaxConn[BDaxConn](dax, "bbb")
 	if !err.IsOk() {
 		return err
 	}
@@ -516,11 +456,11 @@ func (dax BGetSetDax) SetBData(data string) sabi.Err {
 // CSetDax
 
 type CSetDax struct {
-	CDax
+	sabi.Dax
 }
 
 func (dax CSetDax) SetCData(data string) sabi.Err {
-	conn, err := dax.GetCDaxConn("ccc")
+	conn, err := sabi.GetDaxConn[CDaxConn](dax, "ccc")
 	if !err.IsOk() {
 		return err
 	}

--- a/example_dax_test.go
+++ b/example_dax_test.go
@@ -22,7 +22,7 @@ func ExampleAddGlobalDaxSrc() {
 
 	dax := MyDax{Dax: base}
 
-	conn, err := dax.GetDaxConn("hoge")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "hoge")
 	fmt.Printf("conn = %v\n", reflect.TypeOf(conn))
 	fmt.Printf("err.IsOk() = %t\n", err.IsOk())
 
@@ -51,11 +51,11 @@ func ExampleStartUpGlobalDaxSrcs() {
 
 	dax := MyDax{Dax: base}
 
-	conn, err := dax.GetDaxConn("hoge")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "hoge")
 	fmt.Printf("conn = %v\n", reflect.TypeOf(conn))
 	fmt.Printf("err.IsOk() = %v\n", err.IsOk())
 
-	conn, err = dax.GetDaxConn("fuga")
+	conn, err = sabi.GetDaxConn[MapDaxConn](dax, "fuga")
 	fmt.Printf("conn = %v\n", reflect.TypeOf(conn))
 	fmt.Printf("err.IsOk() = %t\n", err.IsOk())
 	fmt.Printf("err.Error() = %s\n", err.Error())
@@ -63,7 +63,7 @@ func ExampleStartUpGlobalDaxSrcs() {
 	// Output:
 	// conn = sabi_test.MapDaxConn
 	// err.IsOk() = true
-	// conn = <nil>
+	// conn = sabi_test.MapDaxConn
 	// err.IsOk() = false
 	// err.Error() = {reason=DaxSrcIsNotFound, Name=fuga}
 
@@ -82,7 +82,7 @@ func ExampleDaxBase_SetUpLocalDaxSrc() {
 
 	dax := MyDax{Dax: base}
 
-	conn, err := dax.GetDaxConn("hoge")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "hoge")
 	fmt.Printf("conn = %v\n", reflect.TypeOf(conn))
 	fmt.Printf("err.IsOk() = %v\n", err.IsOk())
 
@@ -98,11 +98,11 @@ type GettingDax struct {
 }
 
 func (dax GettingDax) GetData() (string, sabi.Err) {
-	conn, err := dax.GetDaxConn("hoge")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "hoge")
 	if !err.IsOk() {
 		return "", err
 	}
-	data := conn.(MapDaxConn).dataMap["hogehoge"]
+	data := conn.dataMap["hogehoge"]
 	return data, err
 }
 
@@ -111,11 +111,11 @@ type SettingDax struct {
 }
 
 func (dax SettingDax) SetData(data string) sabi.Err {
-	conn, err := dax.GetDaxConn("fuga")
+	conn, err := sabi.GetDaxConn[MapDaxConn](dax, "fuga")
 	if !err.IsOk() {
 		return err
 	}
-	conn.(MapDaxConn).dataMap["fugafuga"] = data
+	conn.dataMap["fugafuga"] = data
 	return err
 }
 
@@ -124,7 +124,7 @@ func ExampleDax() {
 	//   sabi.Dax
 	// }
 	// func (dax GettingDax) GetData() (string, sabi.Err) {
-	//   conn, err := dax.GetDaxConn("hoge")
+	//   conn, err := dax.getDaxConn("hoge")
 	//   if !err.IsOk() {
 	//     return nil, err
 	//   }
@@ -135,7 +135,7 @@ func ExampleDax() {
 	//   sabi.Dax
 	// }
 	// func (dax SettingDax) SetData(data string) sabi.Err {
-	//   conn, err := dax.GetDaxConn("fuga")
+	//   conn, err := dax.getDaxConn("fuga")
 	//   if !err.IsOk() {
 	//     return nil, err
 	//   }

--- a/txn_test.go
+++ b/txn_test.go
@@ -23,8 +23,8 @@ func TestRunTxn(t *testing.T) {
 		BGetSetDax
 	}{
 		DaxBase:    base,
-		AGetDax:    AGetDax{ADax: ADax{Dax: base}},
-		BGetSetDax: BGetSetDax{BDax: BDax{Dax: base}},
+		AGetDax:    AGetDax{Dax: base},
+		BGetSetDax: BGetSetDax{Dax: base},
 	}
 
 	aDs := NewADaxSrc()
@@ -90,8 +90,8 @@ func TestRunTxn_failToCreateDaxConn(t *testing.T) {
 		BGetSetDax
 	}{
 		DaxBase:    base,
-		AGetDax:    AGetDax{ADax: ADax{Dax: base}},
-		BGetSetDax: BGetSetDax{BDax: BDax{Dax: base}},
+		AGetDax:    AGetDax{Dax: base},
+		BGetSetDax: BGetSetDax{Dax: base},
 	}
 
 	aDs := NewADaxSrc()
@@ -150,8 +150,8 @@ func TestRunTxn_failToCommitDaxConn(t *testing.T) {
 		BGetSetDax
 	}{
 		DaxBase:    base,
-		AGetDax:    AGetDax{ADax: ADax{Dax: base}},
-		BGetSetDax: BGetSetDax{BDax: BDax{Dax: base}},
+		AGetDax:    AGetDax{Dax: base},
+		BGetSetDax: BGetSetDax{Dax: base},
 	}
 
 	aDs := NewADaxSrc()
@@ -232,8 +232,8 @@ func TestRunTxn_Run_errorInLogic(t *testing.T) {
 		BGetSetDax
 	}{
 		DaxBase:    base,
-		AGetDax:    AGetDax{ADax: ADax{Dax: base}},
-		BGetSetDax: BGetSetDax{BDax: BDax{Dax: base}},
+		AGetDax:    AGetDax{Dax: base},
+		BGetSetDax: BGetSetDax{Dax: base},
 	}
 
 	aDs := NewADaxSrc()


### PR DESCRIPTION
This PR adds a function: `GetDaxConn[D]` which get a `DaxConn` and cast type of it to a type `D` specified as generics type parameter. Along with this, `Dax#GetDaxConn` is hidden, and so is renamed to `Dax#getDaxConn`. 

By this function, a dax interface by a dax source becomes unnecessary. For example:

Before sabi.GetDaxConn[D] function is added:
```
type MapDaxSrc struct {
    m map[string]any
}
func (ds MapDaxSrc) CreateDaxConn() (MapDaxConn, sabi.Err) {
  return MapDaxCon{M:m}, sabi.Ok()
}
func (ds MapDaxSrc) SetUp() sabi.Err { ... }
func (ds MapDaxSrc) End() { ... }

type MapDaxConn struct {
    M map[string]any
}
func (conn MapDaxConn) Commit() sabi.Err { ... }
func (conn MapDaxConn) Rollback() { ... }
func (conn MapDaxConn) Close() { ... }

type MapDax struct {
    sabi.Dax
}
func (dax MapDax) GetMapDaxConn(name string) (MapDaxConn, sabi.Err) {
    conn, err := dax.GetDaxConn(name)
    if err.IsNotOk() { return *new(MapDaxConn), err }
    casted, ok := conn.(MapDaxConn)
    if err.IsNotOk() { return *new(MapDaxConn), sabi.NewErr(sabi.FailToCastDaxConn{ ... }) }
    return casted, sabi.Ok()    
}

type MapGetDax struct {
    MapDax
}
func (dax MapGetDax) GetData() (string, sabi.Err) {
    conn, err := dax.GetMapDaxConn("map")
    if err.IsNotOk() { return "", err }
    return conn.M["data"]
}
```

After sabi.GetDaxConn[D] function is added:
```
type MapDaxSrc struct {
    m map[string]any
}
func (ds MapDaxSrc) CreateDaxConn() (MapDaxConn, sabi.Err) {
  return MapDaxCon{m:m}, sabi.Ok()
}
func (ds MapDaxSrc) SetUp() sabi.Err { ... }
func (ds MapDaxSrc) End() { ... }

type MapDaxConn struct {
    m map[string]any
}
func (conn MapDaxConn) Commit() sabi.Err { ... }
func (conn MapDaxConn) Rollback() { ... }
func (conn MapDaxConn) Close() { ... }

type MapGetDax struct {
    sabi.Dax
}
func (dax MapGetDax) GetData() (string, sabi.Err) {
    conn, err := sabi.GetDaxConn[MapDaxConn](dax, "map")
    if err.IsNotOk() { return "", err }
    return conn.M["data"]
}
```