### PR TITLE
new: added Err#IfOk, Err#IfNotOk, and IfEither

### DIFF
--- a/benchmark_err_test.go
+++ b/benchmark_err_test.go
@@ -587,3 +587,119 @@ func BenchmarkErr_havingCauseReason_ErrorString(b *testing.B) {
 	b.StopTimer()
 	unused(str)
 }
+
+func fn() sabi.Err { return sabi.Ok() }
+
+func BenchmarkError_IfStatement(b *testing.B) {
+	var err sabi.Err
+	var e error = nil
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if e == nil {
+			err = fn()
+		}
+	}
+	b.StopTimer()
+	unused(err)
+}
+
+func BenchmarkErr_IfStatement(b *testing.B) {
+	var err sabi.Err
+	e := sabi.Ok()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if e.IsOk() {
+			err = fn()
+		}
+	}
+	b.StopTimer()
+	unused(err)
+}
+
+func BenchmarkErr_IfOk(b *testing.B) {
+	var err sabi.Err
+	e := sabi.Ok()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		err = e.IfOk(fn)
+	}
+	b.StopTimer()
+	unused(err)
+}
+
+func fnError(err error) sabi.Err {
+	return sabi.Ok()
+}
+func fnErr(err sabi.Err) sabi.Err {
+	return sabi.Ok()
+}
+
+func BenchmarkError_IfNotStatement(b *testing.B) {
+	var err sabi.Err
+	e := returnOneFieldError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if e != nil {
+			err = fnError(e)
+		}
+	}
+	b.StopTimer()
+	unused(err)
+}
+
+func BenchmarkErr_IfNotStatement(b *testing.B) {
+	var err sabi.Err
+	e := returnOneFieldReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if e.IsNotOk() {
+			err = fnErr(e)
+		}
+	}
+	b.StopTimer()
+	unused(err)
+}
+
+func BenchmarkErr_IfNotOk(b *testing.B) {
+	var err sabi.Err
+	e := returnOneFieldReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		err = e.IfNotOk(fnErr)
+	}
+	b.StopTimer()
+	unused(err)
+}
+
+func BenchmarkError_either(b *testing.B) {
+	var err sabi.Err
+	e := returnOneFieldError()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		err = fnError(e)
+	}
+	b.StopTimer()
+	unused(err)
+}
+
+func BenchmarkErr_either(b *testing.B) {
+	var err sabi.Err
+	e := returnOneFieldReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		err = fnErr(e)
+	}
+	b.StopTimer()
+	unused(err)
+}
+
+func BenchmarkErr_IfEither(b *testing.B) {
+	var err sabi.Err
+	e := returnOneFieldReasonedErr()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		err = e.IfEither(fnErr)
+	}
+	b.StopTimer()
+	unused(err)
+}

--- a/err.go
+++ b/err.go
@@ -196,3 +196,28 @@ func (err Err) Situation() map[string]any {
 
 	return m
 }
+
+// IfOk method executes an argument function if this Err indicates non error.
+// If this Err indicates some error, this method just returns this Err.
+func (err Err) IfOk(fn func() Err) Err {
+	if err.IsOk() {
+		return fn()
+	}
+	return err
+}
+
+// IfNotOk method executes an argument function if this Err indicates some
+// error.
+// If this Err indicates non error, this method just returns this Err.
+func (err Err) IfNotOk(fn func(e Err) Err) Err {
+	if err.IsNotOk() {
+		return fn(err)
+	}
+	return err
+}
+
+// IfEither method executes an argument function in either cases that this Err
+// indicates some error or non error.
+func (err Err) IfEither(fn func(e Err) Err) Err {
+	return fn(err)
+}

--- a/err_test.go
+++ b/err_test.go
@@ -210,3 +210,117 @@ func TestOk(t *testing.T) {
 	assert.False(t, errors.Is(err, e))
 	assert.False(t, errors.As(err, &e))
 }
+
+func TestErr_IfOk_ok(t *testing.T) {
+	err := sabi.Ok()
+
+	s := ""
+	err2 := err.IfOk(func() sabi.Err {
+		s = "executed."
+		return sabi.NewErr(InvalidValue{Value: "x"})
+	})
+
+	assert.Equal(t, s, "executed.")
+	assert.True(t, err.IsOk())
+	assert.True(t, err2.IsNotOk())
+	switch err2.Reason().(type) {
+	case InvalidValue:
+	default:
+		assert.Fail(t, err2.Error())
+	}
+}
+
+func TestErr_IfOk_err(t *testing.T) {
+	err := sabi.NewErr(InvalidValue{Value: "x"})
+
+	s := ""
+	err2 := err.IfOk(func() sabi.Err {
+		s = "executed."
+		return sabi.Ok()
+	})
+
+	assert.Equal(t, s, "")
+	assert.True(t, err.IsNotOk())
+	assert.True(t, err2.IsNotOk())
+	switch err2.Reason().(type) {
+	case InvalidValue:
+	default:
+		assert.Fail(t, err2.Error())
+	}
+}
+
+func TestErr_IfNotOk_ok(t *testing.T) {
+	err := sabi.Ok()
+
+	s := ""
+	err2 := err.IfNotOk(func(e sabi.Err) sabi.Err {
+		s = "executed."
+		return sabi.NewErr(InvalidValue{Value: "x"})
+	})
+
+	assert.Equal(t, s, "")
+	assert.True(t, err.IsOk())
+	assert.True(t, err2.IsOk())
+	switch err2.Reason().(type) {
+	case nil:
+	default:
+		assert.Fail(t, err2.Error())
+	}
+}
+
+func TestErr_IfNotOk_err(t *testing.T) {
+	err := sabi.NewErr(InvalidValue{Value: "x"})
+
+	s := ""
+	err2 := err.IfNotOk(func(e sabi.Err) sabi.Err {
+		s = e.Error()
+		return sabi.Ok()
+	})
+
+	assert.Equal(t, s, "{reason=InvalidValue, Value=x}")
+	assert.True(t, err.IsNotOk())
+	assert.True(t, err2.IsOk())
+	switch err2.Reason().(type) {
+	case nil:
+	default:
+		assert.Fail(t, err2.Error())
+	}
+}
+
+func TestErr_IfEither_ok(t *testing.T) {
+	err := sabi.Ok()
+
+	s := ""
+	err2 := err.IfEither(func(e sabi.Err) sabi.Err {
+		s = "executed."
+		return sabi.NewErr(InvalidValue{Value: "x"})
+	})
+
+	assert.Equal(t, s, "executed.")
+	assert.True(t, err.IsOk())
+	assert.True(t, err2.IsNotOk())
+	switch err2.Reason().(type) {
+	case InvalidValue:
+	default:
+		assert.Fail(t, err2.Error())
+	}
+}
+
+func TestErr_IfEither_err(t *testing.T) {
+	err := sabi.NewErr(InvalidValue{Value: "x"})
+
+	s := ""
+	err2 := err.IfEither(func(e sabi.Err) sabi.Err {
+		s = e.Error()
+		return sabi.Ok()
+	})
+
+	assert.Equal(t, s, "{reason=InvalidValue, Value=x}")
+	assert.True(t, err.IsNotOk())
+	assert.True(t, err2.IsOk())
+	switch err2.Reason().(type) {
+	case nil:
+	default:
+		assert.Fail(t, err2.Error())
+	}
+}

--- a/example_err_test.go
+++ b/example_err_test.go
@@ -206,3 +206,55 @@ func ExampleErr_Unwrap() {
 	// errors.As(err, cause1) = true
 	// errors.As(err, cause2) = false
 }
+
+func ExampleErr_IfOk() {
+	err := sabi.Ok()
+	err.IfOk(func() sabi.Err {
+		fmt.Println("execute if non error.")
+		return sabi.Ok()
+	})
+
+	err = sabi.NewErr(FailToDoSomething{})
+	err.IfOk(func() sabi.Err {
+		fmt.Println("not execute if some error.")
+		return sabi.Ok()
+	})
+
+	// Output:
+	// execute if non error.
+}
+
+func ExampleErr_IfNotOk() {
+	err := sabi.Ok()
+	err.IfNotOk(func(e sabi.Err) sabi.Err {
+		fmt.Println("not execute if non error.")
+		return sabi.Ok()
+	})
+
+	err = sabi.NewErr(FailToDoSomething{})
+	err.IfNotOk(func(e sabi.Err) sabi.Err {
+		fmt.Println("execute if some error.")
+		return sabi.Ok()
+	})
+
+	// Output:
+	// execute if some error.
+}
+
+func ExampleErr_IfEither() {
+	err := sabi.Ok()
+	err.IfEither(func(e sabi.Err) sabi.Err {
+		fmt.Println("execute if non error.")
+		return sabi.Ok()
+	})
+
+	err = sabi.NewErr(FailToDoSomething{})
+	err.IfEither(func(e sabi.Err) sabi.Err {
+		fmt.Println("execute if some error.")
+		return sabi.Ok()
+	})
+
+	// Output:
+	// execute if non error.
+	// execute if some error.
+}


### PR DESCRIPTION
This PR adds `IfOk`, `IfNotOk`, and `IfEither` methods to `sabi.Err` type.

By these methods, checking of returned error of a function can be written briefly.

For example,
```
function runA() sabi.Err { ... }
function runB() sabi.Err { ... }

err := runA()
if err.IsNot\Ok() {
    return err
}
return runB()
```
　↓
```
return runA().IfOk(runB)
``` 